### PR TITLE
No longer define defaults for nested inputs in the schema

### DIFF
--- a/provider/pkg/eks_policies/karpenter_controller.go
+++ b/provider/pkg/eks_policies/karpenter_controller.go
@@ -37,7 +37,7 @@ type KarpenterControllerPolicyArgs struct {
 	ClusterID pulumi.StringInput `pulumi:"clusterId"`
 
 	// Tag key (`{key = value}`) applied to resources launched by Karpenter through the Karpenter provisioner.
-	TagKey string `pulumi:"tagKey"`
+	TagKey pulumi.StringInput `pulumi:"tagKey"`
 
 	// List of SSM Parameter ARNs that contain AMI IDs launched by Karpenter.
 	SSMParameterARNs pulumi.StringArrayInput `pulumi:"ssmParameterArns"`
@@ -50,6 +50,14 @@ type KarpenterControllerPolicyArgs struct {
 }
 
 func AttachKarpenterControllerPolicy(ctx *pulumi.Context, policyBuilder *EKSRoleBuilder, partition, awsAccountID string, args KarpenterControllerPolicyArgs) error {
+	if args.ClusterID == nil {
+		args.ClusterID = pulumi.String("*")
+	}
+
+	if args.TagKey == nil {
+		args.TagKey = pulumi.String("karpenter.sh/discovery")
+	}
+
 	karpenterSubnetId := args.SubnetAccountID
 	if karpenterSubnetId == nil {
 		karpenterSubnetId = pulumi.String(awsAccountID)

--- a/provider/pkg/provider/assumable_roles.go
+++ b/provider/pkg/provider/assumable_roles.go
@@ -151,6 +151,21 @@ func NewAssumableRoles(ctx *pulumi.Context, name string, args *AssumableRolesArg
 		return assumeRoleMFA.Json, nil
 	}).(pulumi.StringOutput)
 
+	args.Admin.Name = setDefaultStringPtr(args.Admin.Name, "admin")
+	if args.Admin.RequiresMFA == nil {
+		args.Admin.RequiresMFA = pulumi.Bool(true)
+	}
+
+	args.Poweruser.Name = setDefaultStringPtr(args.Poweruser.Name, "poweruser")
+	if args.Poweruser.RequiresMFA == nil {
+		args.Poweruser.RequiresMFA = pulumi.Bool(true)
+	}
+
+	args.Readonly.Name = setDefaultStringPtr(args.Readonly.Name, "readonly")
+	if args.Readonly.RequiresMFA == nil {
+		args.Readonly.RequiresMFA = pulumi.Bool(true)
+	}
+
 	roleOutput, err := utils.NewAssumableRoles(ctx, name, &utils.IAMAssumableRolesArgs{
 		MaxSessionDuration:  args.MaxSessionDuration,
 		ForceDetachPolicies: args.ForceDetachPolicies,

--- a/provider/pkg/provider/assumable_roles_with_saml.go
+++ b/provider/pkg/provider/assumable_roles_with_saml.go
@@ -84,6 +84,10 @@ func NewAssumableRolesWithSAML(ctx *pulumi.Context, name string, args *Assumable
 		return assumeRole.Json, nil
 	}).(pulumi.StringOutput)
 
+	args.Admin.Name = setDefaultStringPtr(args.Admin.Name, "admin")
+	args.Poweruser.Name = setDefaultStringPtr(args.Poweruser.Name, "poweruser")
+	args.Readonly.Name = setDefaultStringPtr(args.Readonly.Name, "readonly")
+
 	roleOutput, err := utils.NewAssumableRoles(ctx, name, &utils.IAMAssumableRolesArgs{
 		MaxSessionDuration:  args.MaxSessionDuration,
 		ForceDetachPolicies: args.ForceDetachPolicies,

--- a/provider/pkg/provider/utils.go
+++ b/provider/pkg/provider/utils.go
@@ -19,6 +19,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+func setDefaultStringPtr(output pulumi.StringPtrInput, value string) pulumi.StringPtrOutput {
+	if output == nil {
+		output = pulumi.StringPtr("").ToStringPtrOutput()
+	}
+
+	return output.ToStringPtrOutput().ApplyT(func(v *string) *string {
+		if v == nil || *v == "" {
+			v = &value
+		}
+		return v
+	}).(pulumi.StringPtrOutput)
+}
+
 func createAssumableRoleOutput(role *iam.Role, requiresMFA pulumi.BoolInput) AssumableRoleOutput {
 	return AssumableRoleOutput{
 		RoleARN:      role.Arn,

--- a/provider/pkg/provider/utils.go
+++ b/provider/pkg/provider/utils.go
@@ -15,47 +15,9 @@
 package provider
 
 import (
-	"fmt"
-
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
-
-func transformStringArrayToStringArrayOutput(values []string) pulumi.StringArrayOutput {
-	var result []pulumi.StringOutput
-	for _, str := range values {
-		result = append(result, pulumi.Sprintf("%s", str))
-	}
-
-	return pulumi.ToStringArrayOutput(result)
-}
-
-func createRolePolicyAttachment(ctx *pulumi.Context, name, policyArn string, roleName pulumi.StringOutput, opts ...pulumi.ResourceOption) error {
-	_, err := iam.NewRolePolicyAttachment(ctx, name, &iam.RolePolicyAttachmentArgs{
-		Role:      roleName,
-		PolicyArn: pulumi.String(policyArn),
-	}, opts...)
-	return err
-}
-
-func createRoleWithAttachments(ctx *pulumi.Context, name, typ string, policyARNS []string,
-	args *iam.RoleArgs, opts ...pulumi.ResourceOption) (*iam.Role, error) {
-	roleName := fmt.Sprintf("%s-%s-role", name, typ)
-	role, err := iam.NewRole(ctx, roleName, args, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, policyARN := range policyARNS {
-		policyName := fmt.Sprintf("%s-policy-attachment", roleName)
-		err = createRolePolicyAttachment(ctx, policyName, policyARN, role.Name, opts...)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return role, nil
-}
 
 func createAssumableRoleOutput(role *iam.Role, requiresMFA pulumi.BoolInput) AssumableRoleOutput {
 	return AssumableRoleOutput{
@@ -68,14 +30,10 @@ func createAssumableRoleOutput(role *iam.Role, requiresMFA pulumi.BoolInput) Ass
 }
 
 // IAM Policy Document
-
 type IAMPolicyDocumentEffect string
 type IAMPolicyDocumentPrincipalType string
 
 const (
-	iamPolicyDocumentAllowEffect IAMPolicyDocumentEffect = "Allow"
-	iamPolicyDocumentDenyEffect  IAMPolicyDocumentEffect = "Deny"
-
 	iamPolicyDocumentAWSPrincipal       IAMPolicyDocumentPrincipalType = "AWS"
 	iamPolicyDocumentFederatedPrincipal IAMPolicyDocumentPrincipalType = "Federated"
 	iamPolicyDocumentServicePrincipal   IAMPolicyDocumentPrincipalType = "Service"

--- a/schema.yaml
+++ b/schema.yaml
@@ -82,13 +82,11 @@ types:
         properties:
             name:
                 type: string
-                description: IAM role with the access.
-                default: admin
+                description: IAM role with the access. Defaults to 'admin'.
 
             path:
                 type: string
-                description: Path of the IAM role.
-                default: "/"
+                description: Path of the IAM role. Defaults to '/'.
 
             policyArns:
                 type: array
@@ -99,7 +97,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for the role.
-                default: ""
 
             tags:
                 type: object
@@ -110,7 +107,6 @@ types:
             requiresMfa:
                 type: boolean
                 description: Whether the role requires MFA.
-                default: true
 
     "aws-iam:index:EKSServiceAccountRole":
         type: object
@@ -118,17 +114,14 @@ types:
             name:
                 type: string
                 description: IAM role name.
-                default: ""
 
             namePrefix:
                 type: string
                 description: IAM role name prefix.
-                default: ""
 
             path:
                 type: string
                 description: Path of admin IAM role.
-                default: "/"
 
             policyArns:
                 type: array
@@ -139,7 +132,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for the role.
-                default: ""
 
             description:
                 type: string
@@ -152,17 +144,14 @@ types:
             name:
                 type: string
                 description: IAM role name.
-                default: ""
 
             namePrefix:
                 type: string
                 description: IAM role name prefix.
-                default: ""
 
             path:
                 type: string
-                description: Path of admin IAM role.
-                default: "/"
+                description: Path of admin IAM role. Defaults to '/'.
 
             policyArns:
                 type: array
@@ -173,7 +162,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for the role.
-                default: ""
 
     "aws-iam:index:AdminRole":
         type: object
@@ -186,8 +174,7 @@ types:
 
             path:
                 type: string
-                description: Path of admin IAM role.
-                default: "/"
+                description: Path of admin IAM role. Defaults to '/'
 
             policyArns:
                 type: array
@@ -198,7 +185,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for admin role.
-                default: ""
 
             tags:
                 type: object
@@ -227,7 +213,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for admin role.
-                default: ""
 
             tags:
                 type: object
@@ -246,12 +231,10 @@ types:
             name:
                 type: string
                 description: IAM role with poweruser access.
-                default: poweruser
 
             path:
                 type: string
                 description: Path of poweruser IAM role.
-                default: "/"
 
             policyArns:
                 type: array
@@ -262,7 +245,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for poweruser role.
-                default: ""
 
             tags:
                 type: object
@@ -277,12 +259,10 @@ types:
             name:
                 type: string
                 description: IAM role with poweruser access.
-                default: poweruser
 
             path:
                 type: string
                 description: Path of poweruser IAM role.
-                default: "/"
 
             policyArns:
                 type: array
@@ -293,7 +273,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for poweruser role.
-                default: ""
 
             tags:
                 type: object
@@ -304,7 +283,6 @@ types:
             requiresMfa:
                 type: boolean
                 description: Whether admin role requires MFA.
-                default: true
 
     "aws-iam:index:ReadonlyRole":
         type: object
@@ -313,12 +291,10 @@ types:
             name:
                 type: string
                 description: IAM role with readonly access.
-                default: readonly
 
             path:
                 type: string
-                description: Path of readonly IAM role.
-                default: "/"
+                description: Path of readonly IAM role. Defaults to '/'.
 
             policyArns:
                 type: array
@@ -329,7 +305,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for readonly role.
-                default: ""
 
             tags:
                 type: object
@@ -344,12 +319,10 @@ types:
             name:
                 type: string
                 description: IAM role with readonly access.
-                default: readonly
 
             path:
                 type: string
-                description: Path of readonly IAM role.
-                default: "/"
+                description: Path of readonly IAM role. Defaults to '/'.
 
             policyArns:
                 type: array
@@ -360,7 +333,6 @@ types:
             permissionsBoundaryArn:
                 type: string
                 description: Permissions boundary ARN to use for readonly role.
-                default: ""
 
             tags:
                 type: object
@@ -371,7 +343,6 @@ types:
             requiresMfa:
                 type: boolean
                 description: Whether admin role requires MFA.
-                default: true
 
     "aws-iam:index:OIDCProvider":
         type: object

--- a/sdk/dotnet/Inputs/AdminRoleArgs.cs
+++ b/sdk/dotnet/Inputs/AdminRoleArgs.cs
@@ -22,7 +22,7 @@ namespace Pulumi.AwsIam.Inputs
         public Input<string>? Name { get; set; }
 
         /// <summary>
-        /// Path of admin IAM role.
+        /// Path of admin IAM role. Defaults to '/'
         /// </summary>
         [Input("path")]
         public Input<string>? Path { get; set; }
@@ -60,8 +60,6 @@ namespace Pulumi.AwsIam.Inputs
         public AdminRoleArgs()
         {
             Name = "admin";
-            Path = "/";
-            PermissionsBoundaryArn = "";
         }
     }
 }

--- a/sdk/dotnet/Inputs/AdminRoleWithMFAArgs.cs
+++ b/sdk/dotnet/Inputs/AdminRoleWithMFAArgs.cs
@@ -65,7 +65,6 @@ namespace Pulumi.AwsIam.Inputs
 
         public AdminRoleWithMFAArgs()
         {
-            PermissionsBoundaryArn = "";
         }
     }
 }

--- a/sdk/dotnet/Inputs/EKSServiceAccountRoleArgs.cs
+++ b/sdk/dotnet/Inputs/EKSServiceAccountRoleArgs.cs
@@ -56,10 +56,6 @@ namespace Pulumi.AwsIam.Inputs
 
         public EKSServiceAccountRoleArgs()
         {
-            Name = "";
-            NamePrefix = "";
-            Path = "/";
-            PermissionsBoundaryArn = "";
         }
     }
 }

--- a/sdk/dotnet/Inputs/PoweruserRoleArgs.cs
+++ b/sdk/dotnet/Inputs/PoweruserRoleArgs.cs
@@ -59,9 +59,6 @@ namespace Pulumi.AwsIam.Inputs
 
         public PoweruserRoleArgs()
         {
-            Name = "poweruser";
-            Path = "/";
-            PermissionsBoundaryArn = "";
         }
     }
 }

--- a/sdk/dotnet/Inputs/PoweruserRoleWithMFAArgs.cs
+++ b/sdk/dotnet/Inputs/PoweruserRoleWithMFAArgs.cs
@@ -65,10 +65,6 @@ namespace Pulumi.AwsIam.Inputs
 
         public PoweruserRoleWithMFAArgs()
         {
-            Name = "poweruser";
-            Path = "/";
-            PermissionsBoundaryArn = "";
-            RequiresMfa = true;
         }
     }
 }

--- a/sdk/dotnet/Inputs/ReadonlyRoleArgs.cs
+++ b/sdk/dotnet/Inputs/ReadonlyRoleArgs.cs
@@ -22,7 +22,7 @@ namespace Pulumi.AwsIam.Inputs
         public Input<string>? Name { get; set; }
 
         /// <summary>
-        /// Path of readonly IAM role.
+        /// Path of readonly IAM role. Defaults to '/'.
         /// </summary>
         [Input("path")]
         public Input<string>? Path { get; set; }
@@ -59,9 +59,6 @@ namespace Pulumi.AwsIam.Inputs
 
         public ReadonlyRoleArgs()
         {
-            Name = "readonly";
-            Path = "/";
-            PermissionsBoundaryArn = "";
         }
     }
 }

--- a/sdk/dotnet/Inputs/ReadonlyRoleWithMFAArgs.cs
+++ b/sdk/dotnet/Inputs/ReadonlyRoleWithMFAArgs.cs
@@ -22,7 +22,7 @@ namespace Pulumi.AwsIam.Inputs
         public Input<string>? Name { get; set; }
 
         /// <summary>
-        /// Path of readonly IAM role.
+        /// Path of readonly IAM role. Defaults to '/'.
         /// </summary>
         [Input("path")]
         public Input<string>? Path { get; set; }
@@ -65,10 +65,6 @@ namespace Pulumi.AwsIam.Inputs
 
         public ReadonlyRoleWithMFAArgs()
         {
-            Name = "readonly";
-            Path = "/";
-            PermissionsBoundaryArn = "";
-            RequiresMfa = true;
         }
     }
 }

--- a/sdk/dotnet/Inputs/RoleArgs.cs
+++ b/sdk/dotnet/Inputs/RoleArgs.cs
@@ -28,7 +28,7 @@ namespace Pulumi.AwsIam.Inputs
         public Input<string>? NamePrefix { get; set; }
 
         /// <summary>
-        /// Path of admin IAM role.
+        /// Path of admin IAM role. Defaults to '/'.
         /// </summary>
         [Input("path")]
         public Input<string>? Path { get; set; }
@@ -53,10 +53,6 @@ namespace Pulumi.AwsIam.Inputs
 
         public RoleArgs()
         {
-            Name = "";
-            NamePrefix = "";
-            Path = "/";
-            PermissionsBoundaryArn = "";
         }
     }
 }

--- a/sdk/dotnet/Inputs/RoleWithMFAArgs.cs
+++ b/sdk/dotnet/Inputs/RoleWithMFAArgs.cs
@@ -16,13 +16,13 @@ namespace Pulumi.AwsIam.Inputs
     public sealed class RoleWithMFAArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// IAM role with the access.
+        /// IAM role with the access. Defaults to 'admin'.
         /// </summary>
         [Input("name")]
         public Input<string>? Name { get; set; }
 
         /// <summary>
-        /// Path of the IAM role.
+        /// Path of the IAM role. Defaults to '/'.
         /// </summary>
         [Input("path")]
         public Input<string>? Path { get; set; }
@@ -65,10 +65,6 @@ namespace Pulumi.AwsIam.Inputs
 
         public RoleWithMFAArgs()
         {
-            Name = "admin";
-            Path = "/";
-            PermissionsBoundaryArn = "";
-            RequiresMfa = true;
         }
     }
 }

--- a/sdk/go/aws-iam/account.go
+++ b/sdk/go/aws-iam/account.go
@@ -23,33 +23,36 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         account, err := iam.NewAccount(ctx, "account", &iam.AccountArgs{
-//             AccountAlias: pulumi.String("cool-alias"),
-//             PasswordPolicy: iam.AccountPasswordPolicyArgs{
-//                 MinimumLength:              pulumi.IntPtr(37),
-//                 RequireNumbers:             pulumi.Bool(false),
-//                 AllowUsersToChange:         pulumi.Bool(true),
-//                 HardExpiry:                 pulumi.Bool(true),
-//                 RequireSymbols:             pulumi.Bool(true),
-//                 RequireLowercaseCharacters: pulumi.Bool(true),
-//                 RequireUppercaseCharacters: pulumi.Bool(true),
-//             },
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        account, err := iam.NewAccount(ctx, "account", &iam.AccountArgs{
+//	            AccountAlias: pulumi.String("cool-alias"),
+//	            PasswordPolicy: iam.AccountPasswordPolicyArgs{
+//	                MinimumLength:              pulumi.IntPtr(37),
+//	                RequireNumbers:             pulumi.Bool(false),
+//	                AllowUsersToChange:         pulumi.Bool(true),
+//	                HardExpiry:                 pulumi.Bool(true),
+//	                RequireSymbols:             pulumi.Bool(true),
+//	                RequireLowercaseCharacters: pulumi.Bool(true),
+//	                RequireUppercaseCharacters: pulumi.Bool(true),
+//	            },
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("account", account)
+//	        ctx.Export("account", account)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type Account struct {
@@ -130,7 +133,7 @@ func (i *Account) ToAccountOutputWithContext(ctx context.Context) AccountOutput 
 // AccountArrayInput is an input type that accepts AccountArray and AccountArrayOutput values.
 // You can construct a concrete instance of `AccountArrayInput` via:
 //
-//          AccountArray{ AccountArgs{...} }
+//	AccountArray{ AccountArgs{...} }
 type AccountArrayInput interface {
 	pulumi.Input
 
@@ -155,7 +158,7 @@ func (i AccountArray) ToAccountArrayOutputWithContext(ctx context.Context) Accou
 // AccountMapInput is an input type that accepts AccountMap and AccountMapOutput values.
 // You can construct a concrete instance of `AccountMapInput` via:
 //
-//          AccountMap{ "key": AccountArgs{...} }
+//	AccountMap{ "key": AccountArgs{...} }
 type AccountMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/assumableRole.go
+++ b/sdk/go/aws-iam/assumableRole.go
@@ -20,29 +20,32 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         assumableRole, err := iam.NewAssumableRole(ctx, "assumable-role", &iam.AssumableRoleArgs{
-//             TrustedRoleArns: pulumi.ToStringArray([]string{"arn:aws:iam::307990089504:root", "arn:aws:iam::835367859851:user/pulumipus"}),
-//             Role: &iam.RoleWithMFAArgs{
-//                 Name:        pulumi.String("custom"),
-//                 RequiresMfa: pulumi.BoolPtr(true),
-//                 PolicyArns:  pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/AmazonCognitoReadOnly", "arn:aws:iam::aws:policy/AlexaForBusinessFullAccess"}),
-//             },
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        assumableRole, err := iam.NewAssumableRole(ctx, "assumable-role", &iam.AssumableRoleArgs{
+//	            TrustedRoleArns: pulumi.ToStringArray([]string{"arn:aws:iam::307990089504:root", "arn:aws:iam::835367859851:user/pulumipus"}),
+//	            Role: &iam.RoleWithMFAArgs{
+//	                Name:        pulumi.String("custom"),
+//	                RequiresMfa: pulumi.BoolPtr(true),
+//	                PolicyArns:  pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/AmazonCognitoReadOnly", "arn:aws:iam::aws:policy/AlexaForBusinessFullAccess"}),
+//	            },
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("assumableRole", assumableRole)
+//	        ctx.Export("assumableRole", assumableRole)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type AssumableRole struct {
@@ -79,9 +82,6 @@ func NewAssumableRole(ctx *pulumi.Context,
 	}
 	if isZero(args.MfaAge) {
 		args.MfaAge = pulumi.IntPtr(86400)
-	}
-	if args.Role != nil {
-		args.Role = args.Role.ToRoleWithMFAPtrOutput().ApplyT(func(v *RoleWithMFA) *RoleWithMFA { return v.Defaults() }).(RoleWithMFAPtrOutput)
 	}
 	var resource AssumableRole
 	err := ctx.RegisterRemoteComponentResource("aws-iam:index:AssumableRole", name, args, &resource, opts...)
@@ -176,7 +176,7 @@ func (i *AssumableRole) ToAssumableRoleOutputWithContext(ctx context.Context) As
 // AssumableRoleArrayInput is an input type that accepts AssumableRoleArray and AssumableRoleArrayOutput values.
 // You can construct a concrete instance of `AssumableRoleArrayInput` via:
 //
-//          AssumableRoleArray{ AssumableRoleArgs{...} }
+//	AssumableRoleArray{ AssumableRoleArgs{...} }
 type AssumableRoleArrayInput interface {
 	pulumi.Input
 
@@ -201,7 +201,7 @@ func (i AssumableRoleArray) ToAssumableRoleArrayOutputWithContext(ctx context.Co
 // AssumableRoleMapInput is an input type that accepts AssumableRoleMap and AssumableRoleMapOutput values.
 // You can construct a concrete instance of `AssumableRoleMapInput` via:
 //
-//          AssumableRoleMap{ "key": AssumableRoleArgs{...} }
+//	AssumableRoleMap{ "key": AssumableRoleArgs{...} }
 type AssumableRoleMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/assumableRoleWithOIDC.go
+++ b/sdk/go/aws-iam/assumableRoleWithOIDC.go
@@ -20,31 +20,34 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         assumableRoleWithOIDC, err := iam.NewAssumableRoleWithOIDC(ctx, "assumable-role-with-oidc", &iam.AssumableRoleWithOIDCArgs{
-//             Role: iam.RoleArgs{
-//                 Name:       pulumi.String("oidc-role"),
-//                 PolicyArns: pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"}),
-//             },
-//             Tags: pulumi.ToStringMap(map[string]string{
-//                 "Role": "oidc-role",
-//             }),
-//             ProviderUrls: pulumi.ToStringArray([]string{"oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8"}),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        assumableRoleWithOIDC, err := iam.NewAssumableRoleWithOIDC(ctx, "assumable-role-with-oidc", &iam.AssumableRoleWithOIDCArgs{
+//	            Role: iam.RoleArgs{
+//	                Name:       pulumi.String("oidc-role"),
+//	                PolicyArns: pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"}),
+//	            },
+//	            Tags: pulumi.ToStringMap(map[string]string{
+//	                "Role": "oidc-role",
+//	            }),
+//	            ProviderUrls: pulumi.ToStringArray([]string{"oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8"}),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("assumableRoleWithOIDC", assumableRoleWithOIDC)
+//	        ctx.Export("assumableRoleWithOIDC", assumableRoleWithOIDC)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type AssumableRoleWithOIDC struct {
@@ -75,9 +78,6 @@ func NewAssumableRoleWithOIDC(ctx *pulumi.Context,
 	}
 	if isZero(args.MaxSessionDuration) {
 		args.MaxSessionDuration = pulumi.IntPtr(3600)
-	}
-	if args.Role != nil {
-		args.Role = args.Role.ToRolePtrOutput().ApplyT(func(v *Role) *Role { return v.Defaults() }).(RolePtrOutput)
 	}
 	var resource AssumableRoleWithOIDC
 	err := ctx.RegisterRemoteComponentResource("aws-iam:index:AssumableRoleWithOIDC", name, args, &resource, opts...)
@@ -156,7 +156,7 @@ func (i *AssumableRoleWithOIDC) ToAssumableRoleWithOIDCOutputWithContext(ctx con
 // AssumableRoleWithOIDCArrayInput is an input type that accepts AssumableRoleWithOIDCArray and AssumableRoleWithOIDCArrayOutput values.
 // You can construct a concrete instance of `AssumableRoleWithOIDCArrayInput` via:
 //
-//          AssumableRoleWithOIDCArray{ AssumableRoleWithOIDCArgs{...} }
+//	AssumableRoleWithOIDCArray{ AssumableRoleWithOIDCArgs{...} }
 type AssumableRoleWithOIDCArrayInput interface {
 	pulumi.Input
 
@@ -181,7 +181,7 @@ func (i AssumableRoleWithOIDCArray) ToAssumableRoleWithOIDCArrayOutputWithContex
 // AssumableRoleWithOIDCMapInput is an input type that accepts AssumableRoleWithOIDCMap and AssumableRoleWithOIDCMapOutput values.
 // You can construct a concrete instance of `AssumableRoleWithOIDCMapInput` via:
 //
-//          AssumableRoleWithOIDCMap{ "key": AssumableRoleWithOIDCArgs{...} }
+//	AssumableRoleWithOIDCMap{ "key": AssumableRoleWithOIDCArgs{...} }
 type AssumableRoleWithOIDCMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/assumableRoleWithSAML.go
+++ b/sdk/go/aws-iam/assumableRoleWithSAML.go
@@ -20,31 +20,34 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         assumableRoleWithSAML, err := iam.NewAssumableRoleWithSAML(ctx, "assumable-role-with-saml", &iam.AssumableRoleWithSAMLArgs{
-//             Role: iam.RoleArgs{
-//                 Name:       pulumi.String("saml-role"),
-//                 PolicyArns: pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/ReadOnlyAccess"}),
-//             },
-//             Tags: pulumi.ToStringMap(map[string]string{
-//                 "Role": "saml-role",
-//             }),
-//             ProviderIds: pulumi.ToStringArray([]string{"arn:aws:iam::235367859851:saml-provider/idp_saml"}),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        assumableRoleWithSAML, err := iam.NewAssumableRoleWithSAML(ctx, "assumable-role-with-saml", &iam.AssumableRoleWithSAMLArgs{
+//	            Role: iam.RoleArgs{
+//	                Name:       pulumi.String("saml-role"),
+//	                PolicyArns: pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/ReadOnlyAccess"}),
+//	            },
+//	            Tags: pulumi.ToStringMap(map[string]string{
+//	                "Role": "saml-role",
+//	            }),
+//	            ProviderIds: pulumi.ToStringArray([]string{"arn:aws:iam::235367859851:saml-provider/idp_saml"}),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("assumableRoleWithSAML", assumableRoleWithSAML)
+//	        ctx.Export("assumableRoleWithSAML", assumableRoleWithSAML)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type AssumableRoleWithSAML struct {
@@ -75,9 +78,6 @@ func NewAssumableRoleWithSAML(ctx *pulumi.Context,
 	}
 	if isZero(args.MaxSessionDuration) {
 		args.MaxSessionDuration = pulumi.IntPtr(3600)
-	}
-	if args.Role != nil {
-		args.Role = args.Role.ToRolePtrOutput().ApplyT(func(v *Role) *Role { return v.Defaults() }).(RolePtrOutput)
 	}
 	var resource AssumableRoleWithSAML
 	err := ctx.RegisterRemoteComponentResource("aws-iam:index:AssumableRoleWithSAML", name, args, &resource, opts...)
@@ -142,7 +142,7 @@ func (i *AssumableRoleWithSAML) ToAssumableRoleWithSAMLOutputWithContext(ctx con
 // AssumableRoleWithSAMLArrayInput is an input type that accepts AssumableRoleWithSAMLArray and AssumableRoleWithSAMLArrayOutput values.
 // You can construct a concrete instance of `AssumableRoleWithSAMLArrayInput` via:
 //
-//          AssumableRoleWithSAMLArray{ AssumableRoleWithSAMLArgs{...} }
+//	AssumableRoleWithSAMLArray{ AssumableRoleWithSAMLArgs{...} }
 type AssumableRoleWithSAMLArrayInput interface {
 	pulumi.Input
 
@@ -167,7 +167,7 @@ func (i AssumableRoleWithSAMLArray) ToAssumableRoleWithSAMLArrayOutputWithContex
 // AssumableRoleWithSAMLMapInput is an input type that accepts AssumableRoleWithSAMLMap and AssumableRoleWithSAMLMapOutput values.
 // You can construct a concrete instance of `AssumableRoleWithSAMLMapInput` via:
 //
-//          AssumableRoleWithSAMLMap{ "key": AssumableRoleWithSAMLArgs{...} }
+//	AssumableRoleWithSAMLMap{ "key": AssumableRoleWithSAMLArgs{...} }
 type AssumableRoleWithSAMLMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/assumableRoles.go
+++ b/sdk/go/aws-iam/assumableRoles.go
@@ -22,31 +22,34 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         assumableRoles, err := iam.NewAssumableRoles(ctx, "assumable-roles", &iam.AssumableRolesArgs{
-//             TrustedRoleArns: pulumi.ToStringArray([]string{"arn:aws:iam::307990089504:root", "arn:aws:iam::835367859851:user/pulumipus"}),
-//             Admin:           iam.AdminRoleWithMFAArgs{},
-//             Poweruser: iam.PoweruserRoleWithMFAArgs{
-//                 Name: pulumi.String("developer"),
-//             },
-//             Readonly: iam.ReadonlyRoleWithMFAArgs{
-//                 RequiresMfa: pulumi.BoolPtr(true),
-//             },
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        assumableRoles, err := iam.NewAssumableRoles(ctx, "assumable-roles", &iam.AssumableRolesArgs{
+//	            TrustedRoleArns: pulumi.ToStringArray([]string{"arn:aws:iam::307990089504:root", "arn:aws:iam::835367859851:user/pulumipus"}),
+//	            Admin:           iam.AdminRoleWithMFAArgs{},
+//	            Poweruser: iam.PoweruserRoleWithMFAArgs{
+//	                Name: pulumi.String("developer"),
+//	            },
+//	            Readonly: iam.ReadonlyRoleWithMFAArgs{
+//	                RequiresMfa: pulumi.BoolPtr(true),
+//	            },
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("assumableRoles", assumableRoles)
+//	        ctx.Export("assumableRoles", assumableRoles)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type AssumableRoles struct {
@@ -67,7 +70,6 @@ func NewAssumableRoles(ctx *pulumi.Context,
 	if args.Admin == nil {
 		return nil, errors.New("invalid value for required argument 'Admin'")
 	}
-	args.Admin = args.Admin.ToAdminRoleWithMFAOutput().ApplyT(func(v AdminRoleWithMFA) AdminRoleWithMFA { return *v.Defaults() }).(AdminRoleWithMFAOutput)
 	if isZero(args.ForceDetachPolicies) {
 		args.ForceDetachPolicies = pulumi.BoolPtr(false)
 	}
@@ -76,12 +78,6 @@ func NewAssumableRoles(ctx *pulumi.Context,
 	}
 	if isZero(args.MfaAge) {
 		args.MfaAge = pulumi.IntPtr(86400)
-	}
-	if args.Poweruser != nil {
-		args.Poweruser = args.Poweruser.ToPoweruserRoleWithMFAPtrOutput().ApplyT(func(v *PoweruserRoleWithMFA) *PoweruserRoleWithMFA { return v.Defaults() }).(PoweruserRoleWithMFAPtrOutput)
-	}
-	if args.Readonly != nil {
-		args.Readonly = args.Readonly.ToReadonlyRoleWithMFAPtrOutput().ApplyT(func(v *ReadonlyRoleWithMFA) *ReadonlyRoleWithMFA { return v.Defaults() }).(ReadonlyRoleWithMFAPtrOutput)
 	}
 	var resource AssumableRoles
 	err := ctx.RegisterRemoteComponentResource("aws-iam:index:AssumableRoles", name, args, &resource, opts...)
@@ -150,7 +146,7 @@ func (i *AssumableRoles) ToAssumableRolesOutputWithContext(ctx context.Context) 
 // AssumableRolesArrayInput is an input type that accepts AssumableRolesArray and AssumableRolesArrayOutput values.
 // You can construct a concrete instance of `AssumableRolesArrayInput` via:
 //
-//          AssumableRolesArray{ AssumableRolesArgs{...} }
+//	AssumableRolesArray{ AssumableRolesArgs{...} }
 type AssumableRolesArrayInput interface {
 	pulumi.Input
 
@@ -175,7 +171,7 @@ func (i AssumableRolesArray) ToAssumableRolesArrayOutputWithContext(ctx context.
 // AssumableRolesMapInput is an input type that accepts AssumableRolesMap and AssumableRolesMapOutput values.
 // You can construct a concrete instance of `AssumableRolesMapInput` via:
 //
-//          AssumableRolesMap{ "key": AssumableRolesArgs{...} }
+//	AssumableRolesMap{ "key": AssumableRolesArgs{...} }
 type AssumableRolesMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/assumableRolesWithSAML.go
+++ b/sdk/go/aws-iam/assumableRolesWithSAML.go
@@ -20,29 +20,32 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         assumableRolesWithSAML, err := iam.NewAssumableRolesWithSAML(ctx, "assumable-roles-with-saml", &iam.AssumableRolesWithSAMLArgs{
-//             ProviderIds: pulumi.ToStringArray([]string{"arn:aws:iam::235367859851:saml-provider/idp_saml"}),
-//             Admin:       iam.AdminRoleArgs{},
-//             Readonly:    iam.ReadonlyRoleArgs{},
-//             Poweruser: iam.PoweruserRoleArgs{
-//                 Name: pulumi.String("developer"),
-//             },
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        assumableRolesWithSAML, err := iam.NewAssumableRolesWithSAML(ctx, "assumable-roles-with-saml", &iam.AssumableRolesWithSAMLArgs{
+//	            ProviderIds: pulumi.ToStringArray([]string{"arn:aws:iam::235367859851:saml-provider/idp_saml"}),
+//	            Admin:       iam.AdminRoleArgs{},
+//	            Readonly:    iam.ReadonlyRoleArgs{},
+//	            Poweruser: iam.PoweruserRoleArgs{
+//	                Name: pulumi.String("developer"),
+//	            },
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("assumableRolesWithSAML", assumableRolesWithSAML)
+//	        ctx.Export("assumableRolesWithSAML", assumableRolesWithSAML)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type AssumableRolesWithSAML struct {
@@ -71,12 +74,6 @@ func NewAssumableRolesWithSAML(ctx *pulumi.Context,
 	}
 	if isZero(args.MaxSessionDuration) {
 		args.MaxSessionDuration = pulumi.IntPtr(3600)
-	}
-	if args.Poweruser != nil {
-		args.Poweruser = args.Poweruser.ToPoweruserRolePtrOutput().ApplyT(func(v *PoweruserRole) *PoweruserRole { return v.Defaults() }).(PoweruserRolePtrOutput)
-	}
-	if args.Readonly != nil {
-		args.Readonly = args.Readonly.ToReadonlyRolePtrOutput().ApplyT(func(v *ReadonlyRole) *ReadonlyRole { return v.Defaults() }).(ReadonlyRolePtrOutput)
 	}
 	var resource AssumableRolesWithSAML
 	err := ctx.RegisterRemoteComponentResource("aws-iam:index:AssumableRolesWithSAML", name, args, &resource, opts...)
@@ -141,7 +138,7 @@ func (i *AssumableRolesWithSAML) ToAssumableRolesWithSAMLOutputWithContext(ctx c
 // AssumableRolesWithSAMLArrayInput is an input type that accepts AssumableRolesWithSAMLArray and AssumableRolesWithSAMLArrayOutput values.
 // You can construct a concrete instance of `AssumableRolesWithSAMLArrayInput` via:
 //
-//          AssumableRolesWithSAMLArray{ AssumableRolesWithSAMLArgs{...} }
+//	AssumableRolesWithSAMLArray{ AssumableRolesWithSAMLArgs{...} }
 type AssumableRolesWithSAMLArrayInput interface {
 	pulumi.Input
 
@@ -166,7 +163,7 @@ func (i AssumableRolesWithSAMLArray) ToAssumableRolesWithSAMLArrayOutputWithCont
 // AssumableRolesWithSAMLMapInput is an input type that accepts AssumableRolesWithSAMLMap and AssumableRolesWithSAMLMapOutput values.
 // You can construct a concrete instance of `AssumableRolesWithSAMLMapInput` via:
 //
-//          AssumableRolesWithSAMLMap{ "key": AssumableRolesWithSAMLArgs{...} }
+//	AssumableRolesWithSAMLMap{ "key": AssumableRolesWithSAMLArgs{...} }
 type AssumableRolesWithSAMLMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/doc.go
+++ b/sdk/go/aws-iam/doc.go
@@ -1,3 +1,2 @@
 // Package aws-iam exports types, functions, subpackages for provisioning aws-iam resources.
-//
 package awsiam

--- a/sdk/go/aws-iam/eksrole.go
+++ b/sdk/go/aws-iam/eksrole.go
@@ -34,35 +34,38 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         eksRole, err := iam.NewEKSRole(ctx, "eks-role", &iam.EKSRoleArgs{
-//             Role: iam.RoleArgs{
-//                 Name:       pulumi.String("eks-role"),
-//                 PolicyArns: pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"}),
-//             },
-//             Tags: pulumi.ToStringMap(map[string]string{
-//                 "Role": "eks-role",
-//             }),
-//             Uncomment the below and replace actual cluster values.
-//             ClusterServiceAccounts: pulumi.ToStringArrayMap(map[string][]string{
-//                 "staging-main-1": {"default:my-app-staging"},
-//                 "staging-backup-1": {"default:my-app-staging"},
-//             }),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        eksRole, err := iam.NewEKSRole(ctx, "eks-role", &iam.EKSRoleArgs{
+//	            Role: iam.RoleArgs{
+//	                Name:       pulumi.String("eks-role"),
+//	                PolicyArns: pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"}),
+//	            },
+//	            Tags: pulumi.ToStringMap(map[string]string{
+//	                "Role": "eks-role",
+//	            }),
+//	            Uncomment the below and replace actual cluster values.
+//	            ClusterServiceAccounts: pulumi.ToStringArrayMap(map[string][]string{
+//	                "staging-main-1": {"default:my-app-staging"},
+//	                "staging-backup-1": {"default:my-app-staging"},
+//	            }),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("eksRole", eksRole)
+//	        ctx.Export("eksRole", eksRole)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type EKSRole struct {
@@ -90,9 +93,6 @@ func NewEKSRole(ctx *pulumi.Context,
 	}
 	if isZero(args.MaxSessionDuration) {
 		args.MaxSessionDuration = pulumi.IntPtr(3600)
-	}
-	if args.Role != nil {
-		args.Role = args.Role.ToRolePtrOutput().ApplyT(func(v *Role) *Role { return v.Defaults() }).(RolePtrOutput)
 	}
 	var resource EKSRole
 	err := ctx.RegisterRemoteComponentResource("aws-iam:index:EKSRole", name, args, &resource, opts...)
@@ -161,7 +161,7 @@ func (i *EKSRole) ToEKSRoleOutputWithContext(ctx context.Context) EKSRoleOutput 
 // EKSRoleArrayInput is an input type that accepts EKSRoleArray and EKSRoleArrayOutput values.
 // You can construct a concrete instance of `EKSRoleArrayInput` via:
 //
-//          EKSRoleArray{ EKSRoleArgs{...} }
+//	EKSRoleArray{ EKSRoleArgs{...} }
 type EKSRoleArrayInput interface {
 	pulumi.Input
 
@@ -186,7 +186,7 @@ func (i EKSRoleArray) ToEKSRoleArrayOutputWithContext(ctx context.Context) EKSRo
 // EKSRoleMapInput is an input type that accepts EKSRoleMap and EKSRoleMapOutput values.
 // You can construct a concrete instance of `EKSRoleMapInput` via:
 //
-//          EKSRoleMap{ "key": EKSRoleArgs{...} }
+//	EKSRoleMap{ "key": EKSRoleArgs{...} }
 type EKSRoleMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/groupWithAssumableRolesPolicy.go
+++ b/sdk/go/aws-iam/groupWithAssumableRolesPolicy.go
@@ -21,26 +21,29 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         groupWithAssumableRolesPolicy, err := iam.NewGroupWithAssumableRolesPolicy(ctx, "group-with-assumable-roles-policy", &iam.GroupWithAssumableRolesPolicyArgs{
-//             Name:           pulumi.String("production-readonly"),
-//             AssumableRoles: pulumi.ToStringArray([]string{"arn:aws:iam::835367859855:role/readonly"}),
-//             GroupUsers:     pulumi.ToStringArray([]string{"user1", "user2"}),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        groupWithAssumableRolesPolicy, err := iam.NewGroupWithAssumableRolesPolicy(ctx, "group-with-assumable-roles-policy", &iam.GroupWithAssumableRolesPolicyArgs{
+//	            Name:           pulumi.String("production-readonly"),
+//	            AssumableRoles: pulumi.ToStringArray([]string{"arn:aws:iam::835367859855:role/readonly"}),
+//	            GroupUsers:     pulumi.ToStringArray([]string{"user1", "user2"}),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("groupWithAssumableRolesPolicy", groupWithAssumableRolesPolicy)
+//	        ctx.Export("groupWithAssumableRolesPolicy", groupWithAssumableRolesPolicy)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type GroupWithAssumableRolesPolicy struct {
@@ -131,7 +134,7 @@ func (i *GroupWithAssumableRolesPolicy) ToGroupWithAssumableRolesPolicyOutputWit
 // GroupWithAssumableRolesPolicyArrayInput is an input type that accepts GroupWithAssumableRolesPolicyArray and GroupWithAssumableRolesPolicyArrayOutput values.
 // You can construct a concrete instance of `GroupWithAssumableRolesPolicyArrayInput` via:
 //
-//          GroupWithAssumableRolesPolicyArray{ GroupWithAssumableRolesPolicyArgs{...} }
+//	GroupWithAssumableRolesPolicyArray{ GroupWithAssumableRolesPolicyArgs{...} }
 type GroupWithAssumableRolesPolicyArrayInput interface {
 	pulumi.Input
 
@@ -156,7 +159,7 @@ func (i GroupWithAssumableRolesPolicyArray) ToGroupWithAssumableRolesPolicyArray
 // GroupWithAssumableRolesPolicyMapInput is an input type that accepts GroupWithAssumableRolesPolicyMap and GroupWithAssumableRolesPolicyMapOutput values.
 // You can construct a concrete instance of `GroupWithAssumableRolesPolicyMapInput` via:
 //
-//          GroupWithAssumableRolesPolicyMap{ "key": GroupWithAssumableRolesPolicyArgs{...} }
+//	GroupWithAssumableRolesPolicyMap{ "key": GroupWithAssumableRolesPolicyArgs{...} }
 type GroupWithAssumableRolesPolicyMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/groupWithPolicies.go
+++ b/sdk/go/aws-iam/groupWithPolicies.go
@@ -21,33 +21,36 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         groupWithPolicies, err := iam.NewGroupWithPolicies(ctx, "group-with-policies", &iam.GroupWithPoliciesArgs{
-//             Name:                          pulumi.String("superadmins"),
-//             GroupUsers:                    pulumi.ToStringArray([]string{"user1", "user2"}),
-//             AttachIamSelfManagementPolicy: pulumi.BoolPtr(true),
-//             CustomGroupPolicyArns:         pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/AdministratorAccess"}),
-//             CustomGroupPolicies: pulumi.ToStringMapArray([]map[string]string{
-//                 {
-//                     "name":   "AllowS3Listing",
-//                     "policy": "{}",
-//                 },
-//             }),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        groupWithPolicies, err := iam.NewGroupWithPolicies(ctx, "group-with-policies", &iam.GroupWithPoliciesArgs{
+//	            Name:                          pulumi.String("superadmins"),
+//	            GroupUsers:                    pulumi.ToStringArray([]string{"user1", "user2"}),
+//	            AttachIamSelfManagementPolicy: pulumi.BoolPtr(true),
+//	            CustomGroupPolicyArns:         pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/AdministratorAccess"}),
+//	            CustomGroupPolicies: pulumi.ToStringMapArray([]map[string]string{
+//	                {
+//	                    "name":   "AllowS3Listing",
+//	                    "policy": "{}",
+//	                },
+//	            }),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("groupWithPolicies", groupWithPolicies)
+//	        ctx.Export("groupWithPolicies", groupWithPolicies)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type GroupWithPolicies struct {
@@ -158,7 +161,7 @@ func (i *GroupWithPolicies) ToGroupWithPoliciesOutputWithContext(ctx context.Con
 // GroupWithPoliciesArrayInput is an input type that accepts GroupWithPoliciesArray and GroupWithPoliciesArrayOutput values.
 // You can construct a concrete instance of `GroupWithPoliciesArrayInput` via:
 //
-//          GroupWithPoliciesArray{ GroupWithPoliciesArgs{...} }
+//	GroupWithPoliciesArray{ GroupWithPoliciesArgs{...} }
 type GroupWithPoliciesArrayInput interface {
 	pulumi.Input
 
@@ -183,7 +186,7 @@ func (i GroupWithPoliciesArray) ToGroupWithPoliciesArrayOutputWithContext(ctx co
 // GroupWithPoliciesMapInput is an input type that accepts GroupWithPoliciesMap and GroupWithPoliciesMapOutput values.
 // You can construct a concrete instance of `GroupWithPoliciesMapInput` via:
 //
-//          GroupWithPoliciesMap{ "key": GroupWithPoliciesArgs{...} }
+//	GroupWithPoliciesMap{ "key": GroupWithPoliciesArgs{...} }
 type GroupWithPoliciesMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/policy.go
+++ b/sdk/go/aws-iam/policy.go
@@ -20,43 +20,46 @@ import (
 // package main
 //
 // import (
-//     "encoding/json"
 //
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//	"encoding/json"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         policyJSON, err := json.Marshal(map[string]interface{}{
-//             "Version": "2012-10-17",
-//             "Statement": []interface{}{
-//                 map[string]interface{}{
-//                     "Effect":   "Allow",
-//                     "Action":   []string{"ec2:Describe"},
-//                     "Resource": []string{"*"},
-//                 },
-//             },
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        policyJSON, err := json.Marshal(map[string]interface{}{
+//	            "Version": "2012-10-17",
+//	            "Statement": []interface{}{
+//	                map[string]interface{}{
+//	                    "Effect":   "Allow",
+//	                    "Action":   []string{"ec2:Describe"},
+//	                    "Resource": []string{"*"},
+//	                },
+//	            },
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         policy, err := iam.NewPolicy(ctx, "policy", &iam.PolicyArgs{
-//             Name:           pulumi.String("example"),
-//             Path:           pulumi.String("/"),
-//             Description:    pulumi.String("My example policy"),
-//             PolicyDocument: pulumi.String(string(policyJSON)),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	        policy, err := iam.NewPolicy(ctx, "policy", &iam.PolicyArgs{
+//	            Name:           pulumi.String("example"),
+//	            Path:           pulumi.String("/"),
+//	            Description:    pulumi.String("My example policy"),
+//	            PolicyDocument: pulumi.String(string(policyJSON)),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("policy", policy)
+//	        ctx.Export("policy", policy)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type Policy struct {
@@ -156,7 +159,7 @@ func (i *Policy) ToPolicyOutputWithContext(ctx context.Context) PolicyOutput {
 // PolicyArrayInput is an input type that accepts PolicyArray and PolicyArrayOutput values.
 // You can construct a concrete instance of `PolicyArrayInput` via:
 //
-//          PolicyArray{ PolicyArgs{...} }
+//	PolicyArray{ PolicyArgs{...} }
 type PolicyArrayInput interface {
 	pulumi.Input
 
@@ -181,7 +184,7 @@ func (i PolicyArray) ToPolicyArrayOutputWithContext(ctx context.Context) PolicyA
 // PolicyMapInput is an input type that accepts PolicyMap and PolicyMapOutput values.
 // You can construct a concrete instance of `PolicyMapInput` via:
 //
-//          PolicyMap{ "key": PolicyArgs{...} }
+//	PolicyMap{ "key": PolicyArgs{...} }
 type PolicyMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/pulumiTypes.go
+++ b/sdk/go/aws-iam/pulumiTypes.go
@@ -100,7 +100,7 @@ type AccountPasswordPolicy struct {
 // AccountPasswordPolicyInput is an input type that accepts AccountPasswordPolicyArgs and AccountPasswordPolicyOutput values.
 // You can construct a concrete instance of `AccountPasswordPolicyInput` via:
 //
-//          AccountPasswordPolicyArgs{...}
+//	AccountPasswordPolicyArgs{...}
 type AccountPasswordPolicyInput interface {
 	pulumi.Input
 
@@ -214,7 +214,7 @@ func (o AccountPasswordPolicyOutput) ReusePrevention() pulumi.IntPtrOutput {
 type AdminRole struct {
 	// IAM role with admin access.
 	Name *string `pulumi:"name"`
-	// Path of admin IAM role.
+	// Path of admin IAM role. Defaults to '/'
 	Path *string `pulumi:"path"`
 	// Permissions boundary ARN to use for admin role.
 	PermissionsBoundaryArn *string `pulumi:"permissionsBoundaryArn"`
@@ -234,21 +234,13 @@ func (val *AdminRole) Defaults() *AdminRole {
 		name_ := "admin"
 		tmp.Name = &name_
 	}
-	if isZero(tmp.Path) {
-		path_ := "/"
-		tmp.Path = &path_
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
 	return &tmp
 }
 
 // AdminRoleInput is an input type that accepts AdminRoleArgs and AdminRoleOutput values.
 // You can construct a concrete instance of `AdminRoleInput` via:
 //
-//          AdminRoleArgs{...}
+//	AdminRoleArgs{...}
 type AdminRoleInput interface {
 	pulumi.Input
 
@@ -260,7 +252,7 @@ type AdminRoleInput interface {
 type AdminRoleArgs struct {
 	// IAM role with admin access.
 	Name pulumi.StringPtrInput `pulumi:"name"`
-	// Path of admin IAM role.
+	// Path of admin IAM role. Defaults to '/'
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// Permissions boundary ARN to use for admin role.
 	PermissionsBoundaryArn pulumi.StringPtrInput `pulumi:"permissionsBoundaryArn"`
@@ -278,12 +270,6 @@ func (val *AdminRoleArgs) Defaults() *AdminRoleArgs {
 	tmp := *val
 	if isZero(tmp.Name) {
 		tmp.Name = pulumi.StringPtr("admin")
-	}
-	if isZero(tmp.Path) {
-		tmp.Path = pulumi.StringPtr("/")
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
 	}
 	return &tmp
 }
@@ -310,11 +296,11 @@ func (i AdminRoleArgs) ToAdminRolePtrOutputWithContext(ctx context.Context) Admi
 // AdminRolePtrInput is an input type that accepts AdminRoleArgs, AdminRolePtr and AdminRolePtrOutput values.
 // You can construct a concrete instance of `AdminRolePtrInput` via:
 //
-//          AdminRoleArgs{...}
+//	        AdminRoleArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type AdminRolePtrInput interface {
 	pulumi.Input
 
@@ -370,7 +356,7 @@ func (o AdminRoleOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v AdminRole) *string { return v.Name }).(pulumi.StringPtrOutput)
 }
 
-// Path of admin IAM role.
+// Path of admin IAM role. Defaults to '/'
 func (o AdminRoleOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v AdminRole) *string { return v.Path }).(pulumi.StringPtrOutput)
 }
@@ -424,7 +410,7 @@ func (o AdminRolePtrOutput) Name() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Path of admin IAM role.
+// Path of admin IAM role. Defaults to '/'
 func (o AdminRolePtrOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *AdminRole) *string {
 		if v == nil {
@@ -480,23 +466,10 @@ type AdminRoleWithMFA struct {
 	Tags map[string]string `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for AdminRoleWithMFA
-func (val *AdminRoleWithMFA) Defaults() *AdminRoleWithMFA {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
-	return &tmp
-}
-
 // AdminRoleWithMFAInput is an input type that accepts AdminRoleWithMFAArgs and AdminRoleWithMFAOutput values.
 // You can construct a concrete instance of `AdminRoleWithMFAInput` via:
 //
-//          AdminRoleWithMFAArgs{...}
+//	AdminRoleWithMFAArgs{...}
 type AdminRoleWithMFAInput interface {
 	pulumi.Input
 
@@ -520,17 +493,6 @@ type AdminRoleWithMFAArgs struct {
 	Tags pulumi.StringMapInput `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for AdminRoleWithMFAArgs
-func (val *AdminRoleWithMFAArgs) Defaults() *AdminRoleWithMFAArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
-	}
-	return &tmp
-}
 func (AdminRoleWithMFAArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*AdminRoleWithMFA)(nil)).Elem()
 }
@@ -600,7 +562,7 @@ type EKSAmazonManagedServicePrometheusPolicy struct {
 // EKSAmazonManagedServicePrometheusPolicyInput is an input type that accepts EKSAmazonManagedServicePrometheusPolicyArgs and EKSAmazonManagedServicePrometheusPolicyOutput values.
 // You can construct a concrete instance of `EKSAmazonManagedServicePrometheusPolicyInput` via:
 //
-//          EKSAmazonManagedServicePrometheusPolicyArgs{...}
+//	EKSAmazonManagedServicePrometheusPolicyArgs{...}
 type EKSAmazonManagedServicePrometheusPolicyInput interface {
 	pulumi.Input
 
@@ -640,11 +602,11 @@ func (i EKSAmazonManagedServicePrometheusPolicyArgs) ToEKSAmazonManagedServicePr
 // EKSAmazonManagedServicePrometheusPolicyPtrInput is an input type that accepts EKSAmazonManagedServicePrometheusPolicyArgs, EKSAmazonManagedServicePrometheusPolicyPtr and EKSAmazonManagedServicePrometheusPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSAmazonManagedServicePrometheusPolicyPtrInput` via:
 //
-//          EKSAmazonManagedServicePrometheusPolicyArgs{...}
+//	        EKSAmazonManagedServicePrometheusPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSAmazonManagedServicePrometheusPolicyPtrInput interface {
 	pulumi.Input
 
@@ -762,7 +724,7 @@ type EKSAppmeshPolicy struct {
 // EKSAppmeshPolicyInput is an input type that accepts EKSAppmeshPolicyArgs and EKSAppmeshPolicyOutput values.
 // You can construct a concrete instance of `EKSAppmeshPolicyInput` via:
 //
-//          EKSAppmeshPolicyArgs{...}
+//	EKSAppmeshPolicyArgs{...}
 type EKSAppmeshPolicyInput interface {
 	pulumi.Input
 
@@ -801,11 +763,11 @@ func (i EKSAppmeshPolicyArgs) ToEKSAppmeshPolicyPtrOutputWithContext(ctx context
 // EKSAppmeshPolicyPtrInput is an input type that accepts EKSAppmeshPolicyArgs, EKSAppmeshPolicyPtr and EKSAppmeshPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSAppmeshPolicyPtrInput` via:
 //
-//          EKSAppmeshPolicyArgs{...}
+//	        EKSAppmeshPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSAppmeshPolicyPtrInput interface {
 	pulumi.Input
 
@@ -922,7 +884,7 @@ type EKSCertManagerPolicy struct {
 // EKSCertManagerPolicyInput is an input type that accepts EKSCertManagerPolicyArgs and EKSCertManagerPolicyOutput values.
 // You can construct a concrete instance of `EKSCertManagerPolicyInput` via:
 //
-//          EKSCertManagerPolicyArgs{...}
+//	EKSCertManagerPolicyArgs{...}
 type EKSCertManagerPolicyInput interface {
 	pulumi.Input
 
@@ -962,11 +924,11 @@ func (i EKSCertManagerPolicyArgs) ToEKSCertManagerPolicyPtrOutputWithContext(ctx
 // EKSCertManagerPolicyPtrInput is an input type that accepts EKSCertManagerPolicyArgs, EKSCertManagerPolicyPtr and EKSCertManagerPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSCertManagerPolicyPtrInput` via:
 //
-//          EKSCertManagerPolicyArgs{...}
+//	        EKSCertManagerPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSCertManagerPolicyPtrInput interface {
 	pulumi.Input
 
@@ -1084,7 +1046,7 @@ type EKSClusterAutoscalerPolicy struct {
 // EKSClusterAutoscalerPolicyInput is an input type that accepts EKSClusterAutoscalerPolicyArgs and EKSClusterAutoscalerPolicyOutput values.
 // You can construct a concrete instance of `EKSClusterAutoscalerPolicyInput` via:
 //
-//          EKSClusterAutoscalerPolicyArgs{...}
+//	EKSClusterAutoscalerPolicyArgs{...}
 type EKSClusterAutoscalerPolicyInput interface {
 	pulumi.Input
 
@@ -1123,11 +1085,11 @@ func (i EKSClusterAutoscalerPolicyArgs) ToEKSClusterAutoscalerPolicyPtrOutputWit
 // EKSClusterAutoscalerPolicyPtrInput is an input type that accepts EKSClusterAutoscalerPolicyArgs, EKSClusterAutoscalerPolicyPtr and EKSClusterAutoscalerPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSClusterAutoscalerPolicyPtrInput` via:
 //
-//          EKSClusterAutoscalerPolicyArgs{...}
+//	        EKSClusterAutoscalerPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSClusterAutoscalerPolicyPtrInput interface {
 	pulumi.Input
 
@@ -1243,7 +1205,7 @@ type EKSEBSCSIPolicy struct {
 // EKSEBSCSIPolicyInput is an input type that accepts EKSEBSCSIPolicyArgs and EKSEBSCSIPolicyOutput values.
 // You can construct a concrete instance of `EKSEBSCSIPolicyInput` via:
 //
-//          EKSEBSCSIPolicyArgs{...}
+//	EKSEBSCSIPolicyArgs{...}
 type EKSEBSCSIPolicyInput interface {
 	pulumi.Input
 
@@ -1282,11 +1244,11 @@ func (i EKSEBSCSIPolicyArgs) ToEKSEBSCSIPolicyPtrOutputWithContext(ctx context.C
 // EKSEBSCSIPolicyPtrInput is an input type that accepts EKSEBSCSIPolicyArgs, EKSEBSCSIPolicyPtr and EKSEBSCSIPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSEBSCSIPolicyPtrInput` via:
 //
-//          EKSEBSCSIPolicyArgs{...}
+//	        EKSEBSCSIPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSEBSCSIPolicyPtrInput interface {
 	pulumi.Input
 
@@ -1400,7 +1362,7 @@ type EKSEFSCSIPolicy struct {
 // EKSEFSCSIPolicyInput is an input type that accepts EKSEFSCSIPolicyArgs and EKSEFSCSIPolicyOutput values.
 // You can construct a concrete instance of `EKSEFSCSIPolicyInput` via:
 //
-//          EKSEFSCSIPolicyArgs{...}
+//	EKSEFSCSIPolicyArgs{...}
 type EKSEFSCSIPolicyInput interface {
 	pulumi.Input
 
@@ -1437,11 +1399,11 @@ func (i EKSEFSCSIPolicyArgs) ToEKSEFSCSIPolicyPtrOutputWithContext(ctx context.C
 // EKSEFSCSIPolicyPtrInput is an input type that accepts EKSEFSCSIPolicyArgs, EKSEFSCSIPolicyPtr and EKSEFSCSIPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSEFSCSIPolicyPtrInput` via:
 //
-//          EKSEFSCSIPolicyArgs{...}
+//	        EKSEFSCSIPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSEFSCSIPolicyPtrInput interface {
 	pulumi.Input
 
@@ -1543,7 +1505,7 @@ type EKSExternalDNSPolicy struct {
 // EKSExternalDNSPolicyInput is an input type that accepts EKSExternalDNSPolicyArgs and EKSExternalDNSPolicyOutput values.
 // You can construct a concrete instance of `EKSExternalDNSPolicyInput` via:
 //
-//          EKSExternalDNSPolicyArgs{...}
+//	EKSExternalDNSPolicyArgs{...}
 type EKSExternalDNSPolicyInput interface {
 	pulumi.Input
 
@@ -1583,11 +1545,11 @@ func (i EKSExternalDNSPolicyArgs) ToEKSExternalDNSPolicyPtrOutputWithContext(ctx
 // EKSExternalDNSPolicyPtrInput is an input type that accepts EKSExternalDNSPolicyArgs, EKSExternalDNSPolicyPtr and EKSExternalDNSPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSExternalDNSPolicyPtrInput` via:
 //
-//          EKSExternalDNSPolicyArgs{...}
+//	        EKSExternalDNSPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSExternalDNSPolicyPtrInput interface {
 	pulumi.Input
 
@@ -1708,7 +1670,7 @@ type EKSExternalSecretsPolicy struct {
 // EKSExternalSecretsPolicyInput is an input type that accepts EKSExternalSecretsPolicyArgs and EKSExternalSecretsPolicyOutput values.
 // You can construct a concrete instance of `EKSExternalSecretsPolicyInput` via:
 //
-//          EKSExternalSecretsPolicyArgs{...}
+//	EKSExternalSecretsPolicyArgs{...}
 type EKSExternalSecretsPolicyInput interface {
 	pulumi.Input
 
@@ -1750,11 +1712,11 @@ func (i EKSExternalSecretsPolicyArgs) ToEKSExternalSecretsPolicyPtrOutputWithCon
 // EKSExternalSecretsPolicyPtrInput is an input type that accepts EKSExternalSecretsPolicyArgs, EKSExternalSecretsPolicyPtr and EKSExternalSecretsPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSExternalSecretsPolicyPtrInput` via:
 //
-//          EKSExternalSecretsPolicyArgs{...}
+//	        EKSExternalSecretsPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSExternalSecretsPolicyPtrInput interface {
 	pulumi.Input
 
@@ -1914,7 +1876,7 @@ func (val *EKSKarpenterControllerPolicy) Defaults() *EKSKarpenterControllerPolic
 // EKSKarpenterControllerPolicyInput is an input type that accepts EKSKarpenterControllerPolicyArgs and EKSKarpenterControllerPolicyOutput values.
 // You can construct a concrete instance of `EKSKarpenterControllerPolicyInput` via:
 //
-//          EKSKarpenterControllerPolicyArgs{...}
+//	EKSKarpenterControllerPolicyArgs{...}
 type EKSKarpenterControllerPolicyInput interface {
 	pulumi.Input
 
@@ -1977,11 +1939,11 @@ func (i EKSKarpenterControllerPolicyArgs) ToEKSKarpenterControllerPolicyPtrOutpu
 // EKSKarpenterControllerPolicyPtrInput is an input type that accepts EKSKarpenterControllerPolicyArgs, EKSKarpenterControllerPolicyPtr and EKSKarpenterControllerPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSKarpenterControllerPolicyPtrInput` via:
 //
-//          EKSKarpenterControllerPolicyArgs{...}
+//	        EKSKarpenterControllerPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSKarpenterControllerPolicyPtrInput interface {
 	pulumi.Input
 
@@ -2161,7 +2123,7 @@ type EKSLoadBalancerPolicy struct {
 // EKSLoadBalancerPolicyInput is an input type that accepts EKSLoadBalancerPolicyArgs and EKSLoadBalancerPolicyOutput values.
 // You can construct a concrete instance of `EKSLoadBalancerPolicyInput` via:
 //
-//          EKSLoadBalancerPolicyArgs{...}
+//	EKSLoadBalancerPolicyArgs{...}
 type EKSLoadBalancerPolicyInput interface {
 	pulumi.Input
 
@@ -2200,11 +2162,11 @@ func (i EKSLoadBalancerPolicyArgs) ToEKSLoadBalancerPolicyPtrOutputWithContext(c
 // EKSLoadBalancerPolicyPtrInput is an input type that accepts EKSLoadBalancerPolicyArgs, EKSLoadBalancerPolicyPtr and EKSLoadBalancerPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSLoadBalancerPolicyPtrInput` via:
 //
-//          EKSLoadBalancerPolicyArgs{...}
+//	        EKSLoadBalancerPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSLoadBalancerPolicyPtrInput interface {
 	pulumi.Input
 
@@ -2321,7 +2283,7 @@ type EKSNodeTerminationHandlerPolicy struct {
 // EKSNodeTerminationHandlerPolicyInput is an input type that accepts EKSNodeTerminationHandlerPolicyArgs and EKSNodeTerminationHandlerPolicyOutput values.
 // You can construct a concrete instance of `EKSNodeTerminationHandlerPolicyInput` via:
 //
-//          EKSNodeTerminationHandlerPolicyArgs{...}
+//	EKSNodeTerminationHandlerPolicyArgs{...}
 type EKSNodeTerminationHandlerPolicyInput interface {
 	pulumi.Input
 
@@ -2361,11 +2323,11 @@ func (i EKSNodeTerminationHandlerPolicyArgs) ToEKSNodeTerminationHandlerPolicyPt
 // EKSNodeTerminationHandlerPolicyPtrInput is an input type that accepts EKSNodeTerminationHandlerPolicyArgs, EKSNodeTerminationHandlerPolicyPtr and EKSNodeTerminationHandlerPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSNodeTerminationHandlerPolicyPtrInput` via:
 //
-//          EKSNodeTerminationHandlerPolicyArgs{...}
+//	        EKSNodeTerminationHandlerPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSNodeTerminationHandlerPolicyPtrInput interface {
 	pulumi.Input
 
@@ -2518,7 +2480,7 @@ func (val *EKSRolePolicies) Defaults() *EKSRolePolicies {
 // EKSRolePoliciesInput is an input type that accepts EKSRolePoliciesArgs and EKSRolePoliciesOutput values.
 // You can construct a concrete instance of `EKSRolePoliciesInput` via:
 //
-//          EKSRolePoliciesArgs{...}
+//	EKSRolePoliciesArgs{...}
 type EKSRolePoliciesInput interface {
 	pulumi.Input
 
@@ -2590,11 +2552,11 @@ func (i EKSRolePoliciesArgs) ToEKSRolePoliciesPtrOutputWithContext(ctx context.C
 // EKSRolePoliciesPtrInput is an input type that accepts EKSRolePoliciesArgs, EKSRolePoliciesPtr and EKSRolePoliciesPtrOutput values.
 // You can construct a concrete instance of `EKSRolePoliciesPtrInput` via:
 //
-//          EKSRolePoliciesArgs{...}
+//	        EKSRolePoliciesArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSRolePoliciesPtrInput interface {
 	pulumi.Input
 
@@ -2892,7 +2854,7 @@ type EKSServiceAccount struct {
 // EKSServiceAccountInput is an input type that accepts EKSServiceAccountArgs and EKSServiceAccountOutput values.
 // You can construct a concrete instance of `EKSServiceAccountInput` via:
 //
-//          EKSServiceAccountArgs{...}
+//	EKSServiceAccountArgs{...}
 type EKSServiceAccountInput interface {
 	pulumi.Input
 
@@ -2923,7 +2885,7 @@ func (i EKSServiceAccountArgs) ToEKSServiceAccountOutputWithContext(ctx context.
 // EKSServiceAccountArrayInput is an input type that accepts EKSServiceAccountArray and EKSServiceAccountArrayOutput values.
 // You can construct a concrete instance of `EKSServiceAccountArrayInput` via:
 //
-//          EKSServiceAccountArray{ EKSServiceAccountArgs{...} }
+//	EKSServiceAccountArray{ EKSServiceAccountArgs{...} }
 type EKSServiceAccountArrayInput interface {
 	pulumi.Input
 
@@ -3005,35 +2967,10 @@ type EKSServiceAccountRole struct {
 	PolicyArns []string `pulumi:"policyArns"`
 }
 
-// Defaults sets the appropriate defaults for EKSServiceAccountRole
-func (val *EKSServiceAccountRole) Defaults() *EKSServiceAccountRole {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		name_ := ""
-		tmp.Name = &name_
-	}
-	if isZero(tmp.NamePrefix) {
-		namePrefix_ := ""
-		tmp.NamePrefix = &namePrefix_
-	}
-	if isZero(tmp.Path) {
-		path_ := "/"
-		tmp.Path = &path_
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
-	return &tmp
-}
-
 // EKSServiceAccountRoleInput is an input type that accepts EKSServiceAccountRoleArgs and EKSServiceAccountRoleOutput values.
 // You can construct a concrete instance of `EKSServiceAccountRoleInput` via:
 //
-//          EKSServiceAccountRoleArgs{...}
+//	EKSServiceAccountRoleArgs{...}
 type EKSServiceAccountRoleInput interface {
 	pulumi.Input
 
@@ -3056,26 +2993,6 @@ type EKSServiceAccountRoleArgs struct {
 	PolicyArns pulumi.StringArrayInput `pulumi:"policyArns"`
 }
 
-// Defaults sets the appropriate defaults for EKSServiceAccountRoleArgs
-func (val *EKSServiceAccountRoleArgs) Defaults() *EKSServiceAccountRoleArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		tmp.Name = pulumi.StringPtr("")
-	}
-	if isZero(tmp.NamePrefix) {
-		tmp.NamePrefix = pulumi.StringPtr("")
-	}
-	if isZero(tmp.Path) {
-		tmp.Path = pulumi.StringPtr("/")
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
-	}
-	return &tmp
-}
 func (EKSServiceAccountRoleArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*EKSServiceAccountRole)(nil)).Elem()
 }
@@ -3099,11 +3016,11 @@ func (i EKSServiceAccountRoleArgs) ToEKSServiceAccountRolePtrOutputWithContext(c
 // EKSServiceAccountRolePtrInput is an input type that accepts EKSServiceAccountRoleArgs, EKSServiceAccountRolePtr and EKSServiceAccountRolePtrOutput values.
 // You can construct a concrete instance of `EKSServiceAccountRolePtrInput` via:
 //
-//          EKSServiceAccountRoleArgs{...}
+//	        EKSServiceAccountRoleArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSServiceAccountRolePtrInput interface {
 	pulumi.Input
 
@@ -3280,7 +3197,7 @@ type EKSVPNCNIPolicy struct {
 // EKSVPNCNIPolicyInput is an input type that accepts EKSVPNCNIPolicyArgs and EKSVPNCNIPolicyOutput values.
 // You can construct a concrete instance of `EKSVPNCNIPolicyInput` via:
 //
-//          EKSVPNCNIPolicyArgs{...}
+//	EKSVPNCNIPolicyArgs{...}
 type EKSVPNCNIPolicyInput interface {
 	pulumi.Input
 
@@ -3321,11 +3238,11 @@ func (i EKSVPNCNIPolicyArgs) ToEKSVPNCNIPolicyPtrOutputWithContext(ctx context.C
 // EKSVPNCNIPolicyPtrInput is an input type that accepts EKSVPNCNIPolicyArgs, EKSVPNCNIPolicyPtr and EKSVPNCNIPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSVPNCNIPolicyPtrInput` via:
 //
-//          EKSVPNCNIPolicyArgs{...}
+//	        EKSVPNCNIPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSVPNCNIPolicyPtrInput interface {
 	pulumi.Input
 
@@ -3457,7 +3374,7 @@ type EKSVeleroPolicy struct {
 // EKSVeleroPolicyInput is an input type that accepts EKSVeleroPolicyArgs and EKSVeleroPolicyOutput values.
 // You can construct a concrete instance of `EKSVeleroPolicyInput` via:
 //
-//          EKSVeleroPolicyArgs{...}
+//	EKSVeleroPolicyArgs{...}
 type EKSVeleroPolicyInput interface {
 	pulumi.Input
 
@@ -3497,11 +3414,11 @@ func (i EKSVeleroPolicyArgs) ToEKSVeleroPolicyPtrOutputWithContext(ctx context.C
 // EKSVeleroPolicyPtrInput is an input type that accepts EKSVeleroPolicyArgs, EKSVeleroPolicyPtr and EKSVeleroPolicyPtrOutput values.
 // You can construct a concrete instance of `EKSVeleroPolicyPtrInput` via:
 //
-//          EKSVeleroPolicyArgs{...}
+//	        EKSVeleroPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EKSVeleroPolicyPtrInput interface {
 	pulumi.Input
 
@@ -3620,7 +3537,7 @@ type FSxLustreCSIPolicy struct {
 // FSxLustreCSIPolicyInput is an input type that accepts FSxLustreCSIPolicyArgs and FSxLustreCSIPolicyOutput values.
 // You can construct a concrete instance of `FSxLustreCSIPolicyInput` via:
 //
-//          FSxLustreCSIPolicyArgs{...}
+//	FSxLustreCSIPolicyArgs{...}
 type FSxLustreCSIPolicyInput interface {
 	pulumi.Input
 
@@ -3660,11 +3577,11 @@ func (i FSxLustreCSIPolicyArgs) ToFSxLustreCSIPolicyPtrOutputWithContext(ctx con
 // FSxLustreCSIPolicyPtrInput is an input type that accepts FSxLustreCSIPolicyArgs, FSxLustreCSIPolicyPtr and FSxLustreCSIPolicyPtrOutput values.
 // You can construct a concrete instance of `FSxLustreCSIPolicyPtrInput` via:
 //
-//          FSxLustreCSIPolicyArgs{...}
+//	        FSxLustreCSIPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type FSxLustreCSIPolicyPtrInput interface {
 	pulumi.Input
 
@@ -3824,7 +3741,7 @@ type OIDCProvider struct {
 // OIDCProviderInput is an input type that accepts OIDCProviderArgs and OIDCProviderOutput values.
 // You can construct a concrete instance of `OIDCProviderInput` via:
 //
-//          OIDCProviderArgs{...}
+//	OIDCProviderArgs{...}
 type OIDCProviderInput interface {
 	pulumi.Input
 
@@ -3852,7 +3769,7 @@ func (i OIDCProviderArgs) ToOIDCProviderOutputWithContext(ctx context.Context) O
 // OIDCProviderMapInput is an input type that accepts OIDCProviderMap and OIDCProviderMapOutput values.
 // You can construct a concrete instance of `OIDCProviderMapInput` via:
 //
-//          OIDCProviderMap{ "key": OIDCProviderArgs{...} }
+//	OIDCProviderMap{ "key": OIDCProviderArgs{...} }
 type OIDCProviderMapInput interface {
 	pulumi.Input
 
@@ -3930,31 +3847,10 @@ type PoweruserRole struct {
 	Tags map[string]string `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for PoweruserRole
-func (val *PoweruserRole) Defaults() *PoweruserRole {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		name_ := "poweruser"
-		tmp.Name = &name_
-	}
-	if isZero(tmp.Path) {
-		path_ := "/"
-		tmp.Path = &path_
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
-	return &tmp
-}
-
 // PoweruserRoleInput is an input type that accepts PoweruserRoleArgs and PoweruserRoleOutput values.
 // You can construct a concrete instance of `PoweruserRoleInput` via:
 //
-//          PoweruserRoleArgs{...}
+//	PoweruserRoleArgs{...}
 type PoweruserRoleInput interface {
 	pulumi.Input
 
@@ -3976,23 +3872,6 @@ type PoweruserRoleArgs struct {
 	Tags pulumi.StringMapInput `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for PoweruserRoleArgs
-func (val *PoweruserRoleArgs) Defaults() *PoweruserRoleArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		tmp.Name = pulumi.StringPtr("poweruser")
-	}
-	if isZero(tmp.Path) {
-		tmp.Path = pulumi.StringPtr("/")
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
-	}
-	return &tmp
-}
 func (PoweruserRoleArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*PoweruserRole)(nil)).Elem()
 }
@@ -4016,11 +3895,11 @@ func (i PoweruserRoleArgs) ToPoweruserRolePtrOutputWithContext(ctx context.Conte
 // PoweruserRolePtrInput is an input type that accepts PoweruserRoleArgs, PoweruserRolePtr and PoweruserRolePtrOutput values.
 // You can construct a concrete instance of `PoweruserRolePtrInput` via:
 //
-//          PoweruserRoleArgs{...}
+//	        PoweruserRoleArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type PoweruserRolePtrInput interface {
 	pulumi.Input
 
@@ -4186,35 +4065,10 @@ type PoweruserRoleWithMFA struct {
 	Tags map[string]string `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for PoweruserRoleWithMFA
-func (val *PoweruserRoleWithMFA) Defaults() *PoweruserRoleWithMFA {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		name_ := "poweruser"
-		tmp.Name = &name_
-	}
-	if isZero(tmp.Path) {
-		path_ := "/"
-		tmp.Path = &path_
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
-	if isZero(tmp.RequiresMfa) {
-		requiresMfa_ := true
-		tmp.RequiresMfa = &requiresMfa_
-	}
-	return &tmp
-}
-
 // PoweruserRoleWithMFAInput is an input type that accepts PoweruserRoleWithMFAArgs and PoweruserRoleWithMFAOutput values.
 // You can construct a concrete instance of `PoweruserRoleWithMFAInput` via:
 //
-//          PoweruserRoleWithMFAArgs{...}
+//	PoweruserRoleWithMFAArgs{...}
 type PoweruserRoleWithMFAInput interface {
 	pulumi.Input
 
@@ -4238,26 +4092,6 @@ type PoweruserRoleWithMFAArgs struct {
 	Tags pulumi.StringMapInput `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for PoweruserRoleWithMFAArgs
-func (val *PoweruserRoleWithMFAArgs) Defaults() *PoweruserRoleWithMFAArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		tmp.Name = pulumi.StringPtr("poweruser")
-	}
-	if isZero(tmp.Path) {
-		tmp.Path = pulumi.StringPtr("/")
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
-	}
-	if isZero(tmp.RequiresMfa) {
-		tmp.RequiresMfa = pulumi.BoolPtr(true)
-	}
-	return &tmp
-}
 func (PoweruserRoleWithMFAArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*PoweruserRoleWithMFA)(nil)).Elem()
 }
@@ -4281,11 +4115,11 @@ func (i PoweruserRoleWithMFAArgs) ToPoweruserRoleWithMFAPtrOutputWithContext(ctx
 // PoweruserRoleWithMFAPtrInput is an input type that accepts PoweruserRoleWithMFAArgs, PoweruserRoleWithMFAPtr and PoweruserRoleWithMFAPtrOutput values.
 // You can construct a concrete instance of `PoweruserRoleWithMFAPtrInput` via:
 //
-//          PoweruserRoleWithMFAArgs{...}
+//	        PoweruserRoleWithMFAArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type PoweruserRoleWithMFAPtrInput interface {
 	pulumi.Input
 
@@ -4454,7 +4288,7 @@ func (o PoweruserRoleWithMFAPtrOutput) Tags() pulumi.StringMapOutput {
 type ReadonlyRole struct {
 	// IAM role with readonly access.
 	Name *string `pulumi:"name"`
-	// Path of readonly IAM role.
+	// Path of readonly IAM role. Defaults to '/'.
 	Path *string `pulumi:"path"`
 	// Permissions boundary ARN to use for readonly role.
 	PermissionsBoundaryArn *string `pulumi:"permissionsBoundaryArn"`
@@ -4464,31 +4298,10 @@ type ReadonlyRole struct {
 	Tags map[string]string `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for ReadonlyRole
-func (val *ReadonlyRole) Defaults() *ReadonlyRole {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		name_ := "readonly"
-		tmp.Name = &name_
-	}
-	if isZero(tmp.Path) {
-		path_ := "/"
-		tmp.Path = &path_
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
-	return &tmp
-}
-
 // ReadonlyRoleInput is an input type that accepts ReadonlyRoleArgs and ReadonlyRoleOutput values.
 // You can construct a concrete instance of `ReadonlyRoleInput` via:
 //
-//          ReadonlyRoleArgs{...}
+//	ReadonlyRoleArgs{...}
 type ReadonlyRoleInput interface {
 	pulumi.Input
 
@@ -4500,7 +4313,7 @@ type ReadonlyRoleInput interface {
 type ReadonlyRoleArgs struct {
 	// IAM role with readonly access.
 	Name pulumi.StringPtrInput `pulumi:"name"`
-	// Path of readonly IAM role.
+	// Path of readonly IAM role. Defaults to '/'.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// Permissions boundary ARN to use for readonly role.
 	PermissionsBoundaryArn pulumi.StringPtrInput `pulumi:"permissionsBoundaryArn"`
@@ -4510,23 +4323,6 @@ type ReadonlyRoleArgs struct {
 	Tags pulumi.StringMapInput `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for ReadonlyRoleArgs
-func (val *ReadonlyRoleArgs) Defaults() *ReadonlyRoleArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		tmp.Name = pulumi.StringPtr("readonly")
-	}
-	if isZero(tmp.Path) {
-		tmp.Path = pulumi.StringPtr("/")
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
-	}
-	return &tmp
-}
 func (ReadonlyRoleArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*ReadonlyRole)(nil)).Elem()
 }
@@ -4550,11 +4346,11 @@ func (i ReadonlyRoleArgs) ToReadonlyRolePtrOutputWithContext(ctx context.Context
 // ReadonlyRolePtrInput is an input type that accepts ReadonlyRoleArgs, ReadonlyRolePtr and ReadonlyRolePtrOutput values.
 // You can construct a concrete instance of `ReadonlyRolePtrInput` via:
 //
-//          ReadonlyRoleArgs{...}
+//	        ReadonlyRoleArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type ReadonlyRolePtrInput interface {
 	pulumi.Input
 
@@ -4610,7 +4406,7 @@ func (o ReadonlyRoleOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ReadonlyRole) *string { return v.Name }).(pulumi.StringPtrOutput)
 }
 
-// Path of readonly IAM role.
+// Path of readonly IAM role. Defaults to '/'.
 func (o ReadonlyRoleOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ReadonlyRole) *string { return v.Path }).(pulumi.StringPtrOutput)
 }
@@ -4664,7 +4460,7 @@ func (o ReadonlyRolePtrOutput) Name() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Path of readonly IAM role.
+// Path of readonly IAM role. Defaults to '/'.
 func (o ReadonlyRolePtrOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ReadonlyRole) *string {
 		if v == nil {
@@ -4708,7 +4504,7 @@ func (o ReadonlyRolePtrOutput) Tags() pulumi.StringMapOutput {
 type ReadonlyRoleWithMFA struct {
 	// IAM role with readonly access.
 	Name *string `pulumi:"name"`
-	// Path of readonly IAM role.
+	// Path of readonly IAM role. Defaults to '/'.
 	Path *string `pulumi:"path"`
 	// Permissions boundary ARN to use for readonly role.
 	PermissionsBoundaryArn *string `pulumi:"permissionsBoundaryArn"`
@@ -4720,35 +4516,10 @@ type ReadonlyRoleWithMFA struct {
 	Tags map[string]string `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for ReadonlyRoleWithMFA
-func (val *ReadonlyRoleWithMFA) Defaults() *ReadonlyRoleWithMFA {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		name_ := "readonly"
-		tmp.Name = &name_
-	}
-	if isZero(tmp.Path) {
-		path_ := "/"
-		tmp.Path = &path_
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
-	if isZero(tmp.RequiresMfa) {
-		requiresMfa_ := true
-		tmp.RequiresMfa = &requiresMfa_
-	}
-	return &tmp
-}
-
 // ReadonlyRoleWithMFAInput is an input type that accepts ReadonlyRoleWithMFAArgs and ReadonlyRoleWithMFAOutput values.
 // You can construct a concrete instance of `ReadonlyRoleWithMFAInput` via:
 //
-//          ReadonlyRoleWithMFAArgs{...}
+//	ReadonlyRoleWithMFAArgs{...}
 type ReadonlyRoleWithMFAInput interface {
 	pulumi.Input
 
@@ -4760,7 +4531,7 @@ type ReadonlyRoleWithMFAInput interface {
 type ReadonlyRoleWithMFAArgs struct {
 	// IAM role with readonly access.
 	Name pulumi.StringPtrInput `pulumi:"name"`
-	// Path of readonly IAM role.
+	// Path of readonly IAM role. Defaults to '/'.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// Permissions boundary ARN to use for readonly role.
 	PermissionsBoundaryArn pulumi.StringPtrInput `pulumi:"permissionsBoundaryArn"`
@@ -4772,26 +4543,6 @@ type ReadonlyRoleWithMFAArgs struct {
 	Tags pulumi.StringMapInput `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for ReadonlyRoleWithMFAArgs
-func (val *ReadonlyRoleWithMFAArgs) Defaults() *ReadonlyRoleWithMFAArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		tmp.Name = pulumi.StringPtr("readonly")
-	}
-	if isZero(tmp.Path) {
-		tmp.Path = pulumi.StringPtr("/")
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
-	}
-	if isZero(tmp.RequiresMfa) {
-		tmp.RequiresMfa = pulumi.BoolPtr(true)
-	}
-	return &tmp
-}
 func (ReadonlyRoleWithMFAArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*ReadonlyRoleWithMFA)(nil)).Elem()
 }
@@ -4815,11 +4566,11 @@ func (i ReadonlyRoleWithMFAArgs) ToReadonlyRoleWithMFAPtrOutputWithContext(ctx c
 // ReadonlyRoleWithMFAPtrInput is an input type that accepts ReadonlyRoleWithMFAArgs, ReadonlyRoleWithMFAPtr and ReadonlyRoleWithMFAPtrOutput values.
 // You can construct a concrete instance of `ReadonlyRoleWithMFAPtrInput` via:
 //
-//          ReadonlyRoleWithMFAArgs{...}
+//	        ReadonlyRoleWithMFAArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type ReadonlyRoleWithMFAPtrInput interface {
 	pulumi.Input
 
@@ -4875,7 +4626,7 @@ func (o ReadonlyRoleWithMFAOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ReadonlyRoleWithMFA) *string { return v.Name }).(pulumi.StringPtrOutput)
 }
 
-// Path of readonly IAM role.
+// Path of readonly IAM role. Defaults to '/'.
 func (o ReadonlyRoleWithMFAOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ReadonlyRoleWithMFA) *string { return v.Path }).(pulumi.StringPtrOutput)
 }
@@ -4934,7 +4685,7 @@ func (o ReadonlyRoleWithMFAPtrOutput) Name() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Path of readonly IAM role.
+// Path of readonly IAM role. Defaults to '/'.
 func (o ReadonlyRoleWithMFAPtrOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ReadonlyRoleWithMFA) *string {
 		if v == nil {
@@ -4990,7 +4741,7 @@ type Role struct {
 	Name *string `pulumi:"name"`
 	// IAM role name prefix.
 	NamePrefix *string `pulumi:"namePrefix"`
-	// Path of admin IAM role.
+	// Path of admin IAM role. Defaults to '/'.
 	Path *string `pulumi:"path"`
 	// Permissions boundary ARN to use for the role.
 	PermissionsBoundaryArn *string `pulumi:"permissionsBoundaryArn"`
@@ -4998,35 +4749,10 @@ type Role struct {
 	PolicyArns []string `pulumi:"policyArns"`
 }
 
-// Defaults sets the appropriate defaults for Role
-func (val *Role) Defaults() *Role {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		name_ := ""
-		tmp.Name = &name_
-	}
-	if isZero(tmp.NamePrefix) {
-		namePrefix_ := ""
-		tmp.NamePrefix = &namePrefix_
-	}
-	if isZero(tmp.Path) {
-		path_ := "/"
-		tmp.Path = &path_
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
-	return &tmp
-}
-
 // RoleInput is an input type that accepts RoleArgs and RoleOutput values.
 // You can construct a concrete instance of `RoleInput` via:
 //
-//          RoleArgs{...}
+//	RoleArgs{...}
 type RoleInput interface {
 	pulumi.Input
 
@@ -5040,7 +4766,7 @@ type RoleArgs struct {
 	Name pulumi.StringPtrInput `pulumi:"name"`
 	// IAM role name prefix.
 	NamePrefix pulumi.StringPtrInput `pulumi:"namePrefix"`
-	// Path of admin IAM role.
+	// Path of admin IAM role. Defaults to '/'.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// Permissions boundary ARN to use for the role.
 	PermissionsBoundaryArn pulumi.StringPtrInput `pulumi:"permissionsBoundaryArn"`
@@ -5048,26 +4774,6 @@ type RoleArgs struct {
 	PolicyArns pulumi.StringArrayInput `pulumi:"policyArns"`
 }
 
-// Defaults sets the appropriate defaults for RoleArgs
-func (val *RoleArgs) Defaults() *RoleArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		tmp.Name = pulumi.StringPtr("")
-	}
-	if isZero(tmp.NamePrefix) {
-		tmp.NamePrefix = pulumi.StringPtr("")
-	}
-	if isZero(tmp.Path) {
-		tmp.Path = pulumi.StringPtr("/")
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
-	}
-	return &tmp
-}
 func (RoleArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*Role)(nil)).Elem()
 }
@@ -5091,11 +4797,11 @@ func (i RoleArgs) ToRolePtrOutputWithContext(ctx context.Context) RolePtrOutput 
 // RolePtrInput is an input type that accepts RoleArgs, RolePtr and RolePtrOutput values.
 // You can construct a concrete instance of `RolePtrInput` via:
 //
-//          RoleArgs{...}
+//	        RoleArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type RolePtrInput interface {
 	pulumi.Input
 
@@ -5156,7 +4862,7 @@ func (o RoleOutput) NamePrefix() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Role) *string { return v.NamePrefix }).(pulumi.StringPtrOutput)
 }
 
-// Path of admin IAM role.
+// Path of admin IAM role. Defaults to '/'.
 func (o RoleOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Role) *string { return v.Path }).(pulumi.StringPtrOutput)
 }
@@ -5215,7 +4921,7 @@ func (o RolePtrOutput) NamePrefix() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Path of admin IAM role.
+// Path of admin IAM role. Defaults to '/'.
 func (o RolePtrOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Role) *string {
 		if v == nil {
@@ -5247,9 +4953,9 @@ func (o RolePtrOutput) PolicyArns() pulumi.StringArrayOutput {
 
 // An IAM role that requires MFA.
 type RoleWithMFA struct {
-	// IAM role with the access.
+	// IAM role with the access. Defaults to 'admin'.
 	Name *string `pulumi:"name"`
-	// Path of the IAM role.
+	// Path of the IAM role. Defaults to '/'.
 	Path *string `pulumi:"path"`
 	// Permissions boundary ARN to use for the role.
 	PermissionsBoundaryArn *string `pulumi:"permissionsBoundaryArn"`
@@ -5261,35 +4967,10 @@ type RoleWithMFA struct {
 	Tags map[string]string `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for RoleWithMFA
-func (val *RoleWithMFA) Defaults() *RoleWithMFA {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		name_ := "admin"
-		tmp.Name = &name_
-	}
-	if isZero(tmp.Path) {
-		path_ := "/"
-		tmp.Path = &path_
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		permissionsBoundaryArn_ := ""
-		tmp.PermissionsBoundaryArn = &permissionsBoundaryArn_
-	}
-	if isZero(tmp.RequiresMfa) {
-		requiresMfa_ := true
-		tmp.RequiresMfa = &requiresMfa_
-	}
-	return &tmp
-}
-
 // RoleWithMFAInput is an input type that accepts RoleWithMFAArgs and RoleWithMFAOutput values.
 // You can construct a concrete instance of `RoleWithMFAInput` via:
 //
-//          RoleWithMFAArgs{...}
+//	RoleWithMFAArgs{...}
 type RoleWithMFAInput interface {
 	pulumi.Input
 
@@ -5299,9 +4980,9 @@ type RoleWithMFAInput interface {
 
 // An IAM role that requires MFA.
 type RoleWithMFAArgs struct {
-	// IAM role with the access.
+	// IAM role with the access. Defaults to 'admin'.
 	Name pulumi.StringPtrInput `pulumi:"name"`
-	// Path of the IAM role.
+	// Path of the IAM role. Defaults to '/'.
 	Path pulumi.StringPtrInput `pulumi:"path"`
 	// Permissions boundary ARN to use for the role.
 	PermissionsBoundaryArn pulumi.StringPtrInput `pulumi:"permissionsBoundaryArn"`
@@ -5313,26 +4994,6 @@ type RoleWithMFAArgs struct {
 	Tags pulumi.StringMapInput `pulumi:"tags"`
 }
 
-// Defaults sets the appropriate defaults for RoleWithMFAArgs
-func (val *RoleWithMFAArgs) Defaults() *RoleWithMFAArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if isZero(tmp.Name) {
-		tmp.Name = pulumi.StringPtr("admin")
-	}
-	if isZero(tmp.Path) {
-		tmp.Path = pulumi.StringPtr("/")
-	}
-	if isZero(tmp.PermissionsBoundaryArn) {
-		tmp.PermissionsBoundaryArn = pulumi.StringPtr("")
-	}
-	if isZero(tmp.RequiresMfa) {
-		tmp.RequiresMfa = pulumi.BoolPtr(true)
-	}
-	return &tmp
-}
 func (RoleWithMFAArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*RoleWithMFA)(nil)).Elem()
 }
@@ -5356,11 +5017,11 @@ func (i RoleWithMFAArgs) ToRoleWithMFAPtrOutputWithContext(ctx context.Context) 
 // RoleWithMFAPtrInput is an input type that accepts RoleWithMFAArgs, RoleWithMFAPtr and RoleWithMFAPtrOutput values.
 // You can construct a concrete instance of `RoleWithMFAPtrInput` via:
 //
-//          RoleWithMFAArgs{...}
+//	        RoleWithMFAArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type RoleWithMFAPtrInput interface {
 	pulumi.Input
 
@@ -5411,12 +5072,12 @@ func (o RoleWithMFAOutput) ToRoleWithMFAPtrOutputWithContext(ctx context.Context
 	}).(RoleWithMFAPtrOutput)
 }
 
-// IAM role with the access.
+// IAM role with the access. Defaults to 'admin'.
 func (o RoleWithMFAOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v RoleWithMFA) *string { return v.Name }).(pulumi.StringPtrOutput)
 }
 
-// Path of the IAM role.
+// Path of the IAM role. Defaults to '/'.
 func (o RoleWithMFAOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v RoleWithMFA) *string { return v.Path }).(pulumi.StringPtrOutput)
 }
@@ -5465,7 +5126,7 @@ func (o RoleWithMFAPtrOutput) Elem() RoleWithMFAOutput {
 	}).(RoleWithMFAOutput)
 }
 
-// IAM role with the access.
+// IAM role with the access. Defaults to 'admin'.
 func (o RoleWithMFAPtrOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *RoleWithMFA) *string {
 		if v == nil {
@@ -5475,7 +5136,7 @@ func (o RoleWithMFAPtrOutput) Name() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Path of the IAM role.
+// Path of the IAM role. Defaults to '/'.
 func (o RoleWithMFAPtrOutput) Path() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *RoleWithMFA) *string {
 		if v == nil {

--- a/sdk/go/aws-iam/readOnlyPolicy.go
+++ b/sdk/go/aws-iam/readOnlyPolicy.go
@@ -22,27 +22,30 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         readOnlyPolicy, err := iam.NewReadOnlyPolicy(ctx, "read-only-policy", &iam.ReadOnlyPolicyArgs{
-//             Name:            pulumi.String("example"),
-//             Path:            pulumi.String("/"),
-//             Description:     pulumi.String("My example policy"),
-//             AllowedServices: pulumi.ToStringArray([]string{"rds", "dynamodb"}),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        readOnlyPolicy, err := iam.NewReadOnlyPolicy(ctx, "read-only-policy", &iam.ReadOnlyPolicyArgs{
+//	            Name:            pulumi.String("example"),
+//	            Path:            pulumi.String("/"),
+//	            Description:     pulumi.String("My example policy"),
+//	            AllowedServices: pulumi.ToStringArray([]string{"rds", "dynamodb"}),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("readOnlyPolicy", readOnlyPolicy)
+//	        ctx.Export("readOnlyPolicy", readOnlyPolicy)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type ReadOnlyPolicy struct {
@@ -173,7 +176,7 @@ func (i *ReadOnlyPolicy) ToReadOnlyPolicyOutputWithContext(ctx context.Context) 
 // ReadOnlyPolicyArrayInput is an input type that accepts ReadOnlyPolicyArray and ReadOnlyPolicyArrayOutput values.
 // You can construct a concrete instance of `ReadOnlyPolicyArrayInput` via:
 //
-//          ReadOnlyPolicyArray{ ReadOnlyPolicyArgs{...} }
+//	ReadOnlyPolicyArray{ ReadOnlyPolicyArgs{...} }
 type ReadOnlyPolicyArrayInput interface {
 	pulumi.Input
 
@@ -198,7 +201,7 @@ func (i ReadOnlyPolicyArray) ToReadOnlyPolicyArrayOutputWithContext(ctx context.
 // ReadOnlyPolicyMapInput is an input type that accepts ReadOnlyPolicyMap and ReadOnlyPolicyMapOutput values.
 // You can construct a concrete instance of `ReadOnlyPolicyMapInput` via:
 //
-//          ReadOnlyPolicyMap{ "key": ReadOnlyPolicyArgs{...} }
+//	ReadOnlyPolicyMap{ "key": ReadOnlyPolicyArgs{...} }
 type ReadOnlyPolicyMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/roleForServiceAccountsEks.go
+++ b/sdk/go/aws-iam/roleForServiceAccountsEks.go
@@ -37,41 +37,44 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         roleForServiceAccountsEKS, err := iam.NewRoleForServiceAccountsEks(ctx, "role-for-service-accounts-eks", &iam.RoleForServiceAccountsEksArgs{
-//             Role: iam.EKSServiceAccountRolePtr(&iam.EKSServiceAccountRoleArgs{
-//                 Name: pulumi.String("vpc-cni"),
-//             }),
-//             Tags: pulumi.ToStringMap(map[string]string{
-//                 "Name": "vpc-cni-irsa",
-//             }),
-//             OidcProviders: iam.OIDCProviderMap{
-//                 "main": iam.OIDCProviderArgs{
-//                     ProviderArn:              pulumi.String("arn:aws:iam::012345678901:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/5C54DDF35ER19312844C7333374CC09D"),
-//                     NamespaceServiceAccounts: pulumi.ToStringArray([]string{"default:my-app", "canary:my-app"}),
-//                 },
-//             },
-//             Policies: iam.EKSRolePoliciesPtr(&iam.EKSRolePoliciesArgs{
-//                 VpnCni: iam.EKSVPNCNIPolicyPtr(&iam.EKSVPNCNIPolicyArgs{
-//                     Attach:     pulumi.Bool(true),
-//                     EnableIpv4: pulumi.BoolPtr(true),
-//                 }),
-//             }),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        roleForServiceAccountsEKS, err := iam.NewRoleForServiceAccountsEks(ctx, "role-for-service-accounts-eks", &iam.RoleForServiceAccountsEksArgs{
+//	            Role: iam.EKSServiceAccountRolePtr(&iam.EKSServiceAccountRoleArgs{
+//	                Name: pulumi.String("vpc-cni"),
+//	            }),
+//	            Tags: pulumi.ToStringMap(map[string]string{
+//	                "Name": "vpc-cni-irsa",
+//	            }),
+//	            OidcProviders: iam.OIDCProviderMap{
+//	                "main": iam.OIDCProviderArgs{
+//	                    ProviderArn:              pulumi.String("arn:aws:iam::012345678901:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/5C54DDF35ER19312844C7333374CC09D"),
+//	                    NamespaceServiceAccounts: pulumi.ToStringArray([]string{"default:my-app", "canary:my-app"}),
+//	                },
+//	            },
+//	            Policies: iam.EKSRolePoliciesPtr(&iam.EKSRolePoliciesArgs{
+//	                VpnCni: iam.EKSVPNCNIPolicyPtr(&iam.EKSVPNCNIPolicyArgs{
+//	                    Attach:     pulumi.Bool(true),
+//	                    EnableIpv4: pulumi.BoolPtr(true),
+//	                }),
+//	            }),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("roleForServiceAccountsEKS", roleForServiceAccountsEKS)
+//	        ctx.Export("roleForServiceAccountsEKS", roleForServiceAccountsEKS)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type RoleForServiceAccountsEks struct {
@@ -101,9 +104,6 @@ func NewRoleForServiceAccountsEks(ctx *pulumi.Context,
 	}
 	if isZero(args.PolicyNamePrefix) {
 		args.PolicyNamePrefix = pulumi.StringPtr("AmazonEKS_")
-	}
-	if args.Role != nil {
-		args.Role = args.Role.ToEKSServiceAccountRolePtrOutput().ApplyT(func(v *EKSServiceAccountRole) *EKSServiceAccountRole { return v.Defaults() }).(EKSServiceAccountRolePtrOutput)
 	}
 	var resource RoleForServiceAccountsEks
 	err := ctx.RegisterRemoteComponentResource("aws-iam:index:RoleForServiceAccountsEks", name, args, &resource, opts...)
@@ -174,7 +174,7 @@ func (i *RoleForServiceAccountsEks) ToRoleForServiceAccountsEksOutputWithContext
 // RoleForServiceAccountsEksArrayInput is an input type that accepts RoleForServiceAccountsEksArray and RoleForServiceAccountsEksArrayOutput values.
 // You can construct a concrete instance of `RoleForServiceAccountsEksArrayInput` via:
 //
-//          RoleForServiceAccountsEksArray{ RoleForServiceAccountsEksArgs{...} }
+//	RoleForServiceAccountsEksArray{ RoleForServiceAccountsEksArgs{...} }
 type RoleForServiceAccountsEksArrayInput interface {
 	pulumi.Input
 
@@ -199,7 +199,7 @@ func (i RoleForServiceAccountsEksArray) ToRoleForServiceAccountsEksArrayOutputWi
 // RoleForServiceAccountsEksMapInput is an input type that accepts RoleForServiceAccountsEksMap and RoleForServiceAccountsEksMapOutput values.
 // You can construct a concrete instance of `RoleForServiceAccountsEksMapInput` via:
 //
-//          RoleForServiceAccountsEksMap{ "key": RoleForServiceAccountsEksArgs{...} }
+//	RoleForServiceAccountsEksMap{ "key": RoleForServiceAccountsEksArgs{...} }
 type RoleForServiceAccountsEksMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-iam/user.go
+++ b/sdk/go/aws-iam/user.go
@@ -21,27 +21,30 @@ import (
 // package main
 //
 // import (
-//     iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
-//     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	iam "github.com/pulumi/pulumi-aws-iam/sdk/go/aws-iam"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-//     pulumi.Run(func(ctx *pulumi.Context) error {
-//         user, err := iam.NewUser(ctx, "user", &iam.UserArgs{
-//             Name:                  pulumi.String("pulumipus"),
-//             ForceDestroy:          pulumi.BoolPtr(true),
-//             PgpKey:                pulumi.String("keybase:test"),
-//             PasswordResetRequired: pulumi.BoolPtr(false),
-//         })
-//         if err != nil {
-//             return err
-//         }
+//	func main() {
+//	    pulumi.Run(func(ctx *pulumi.Context) error {
+//	        user, err := iam.NewUser(ctx, "user", &iam.UserArgs{
+//	            Name:                  pulumi.String("pulumipus"),
+//	            ForceDestroy:          pulumi.BoolPtr(true),
+//	            PgpKey:                pulumi.String("keybase:test"),
+//	            PasswordResetRequired: pulumi.BoolPtr(false),
+//	        })
+//	        if err != nil {
+//	            return err
+//	        }
 //
-//         ctx.Export("user", user)
+//	        ctx.Export("user", user)
 //
-//         return nil
-//     })
-// }
+//	        return nil
+//	    })
+//	}
+//
 // ```
 // {{ /example }}
 type User struct {
@@ -157,7 +160,7 @@ func (i *User) ToUserOutputWithContext(ctx context.Context) UserOutput {
 // UserArrayInput is an input type that accepts UserArray and UserArrayOutput values.
 // You can construct a concrete instance of `UserArrayInput` via:
 //
-//          UserArray{ UserArgs{...} }
+//	UserArray{ UserArgs{...} }
 type UserArrayInput interface {
 	pulumi.Input
 
@@ -182,7 +185,7 @@ func (i UserArray) ToUserArrayOutputWithContext(ctx context.Context) UserArrayOu
 // UserMapInput is an input type that accepts UserMap and UserMapOutput values.
 // You can construct a concrete instance of `UserMapInput` via:
 //
-//          UserMap{ "key": UserArgs{...} }
+//	UserMap{ "key": UserArgs{...} }
 type UserMapInput interface {
 	pulumi.Input
 

--- a/sdk/nodejs/assumableRole.ts
+++ b/sdk/nodejs/assumableRole.ts
@@ -62,7 +62,7 @@ export class AssumableRole extends pulumi.ComponentResource {
             resourceInputs["forceDetachPolicies"] = (args ? args.forceDetachPolicies : undefined) ?? false;
             resourceInputs["maxSessionDuration"] = (args ? args.maxSessionDuration : undefined) ?? 3600;
             resourceInputs["mfaAge"] = (args ? args.mfaAge : undefined) ?? 86400;
-            resourceInputs["role"] = args ? (args.role ? pulumi.output(args.role).apply(inputs.roleWithMFAArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["role"] = args ? args.role : undefined;
             resourceInputs["roleStsExternalIds"] = args ? args.roleStsExternalIds : undefined;
             resourceInputs["tags"] = args ? args.tags : undefined;
             resourceInputs["trustedRoleActions"] = args ? args.trustedRoleActions : undefined;

--- a/sdk/nodejs/assumableRoleWithOIDC.ts
+++ b/sdk/nodejs/assumableRoleWithOIDC.ts
@@ -78,7 +78,7 @@ export class AssumableRoleWithOIDC extends pulumi.ComponentResource {
             resourceInputs["oidcFullyQualifiedSubjects"] = args ? args.oidcFullyQualifiedSubjects : undefined;
             resourceInputs["oidcSubjectsWithWildcards"] = args ? args.oidcSubjectsWithWildcards : undefined;
             resourceInputs["providerUrls"] = args ? args.providerUrls : undefined;
-            resourceInputs["role"] = args ? (args.role ? pulumi.output(args.role).apply(inputs.roleArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["role"] = args ? args.role : undefined;
             resourceInputs["tags"] = args ? args.tags : undefined;
             resourceInputs["arn"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;

--- a/sdk/nodejs/assumableRoleWithSAML.ts
+++ b/sdk/nodejs/assumableRoleWithSAML.ts
@@ -75,7 +75,7 @@ export class AssumableRoleWithSAML extends pulumi.ComponentResource {
             resourceInputs["forceDetachPolicies"] = (args ? args.forceDetachPolicies : undefined) ?? false;
             resourceInputs["maxSessionDuration"] = (args ? args.maxSessionDuration : undefined) ?? 3600;
             resourceInputs["providerIds"] = args ? args.providerIds : undefined;
-            resourceInputs["role"] = args ? (args.role ? pulumi.output(args.role).apply(inputs.roleArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["role"] = args ? args.role : undefined;
             resourceInputs["tags"] = args ? args.tags : undefined;
             resourceInputs["roleArn"] = undefined /*out*/;
             resourceInputs["roleName"] = undefined /*out*/;

--- a/sdk/nodejs/assumableRoles.ts
+++ b/sdk/nodejs/assumableRoles.ts
@@ -62,12 +62,12 @@ export class AssumableRoles extends pulumi.ComponentResource {
             if ((!args || args.admin === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'admin'");
             }
-            resourceInputs["admin"] = args ? (args.admin ? pulumi.output(args.admin).apply(inputs.adminRoleWithMFAArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["admin"] = args ? args.admin : undefined;
             resourceInputs["forceDetachPolicies"] = (args ? args.forceDetachPolicies : undefined) ?? false;
             resourceInputs["maxSessionDuration"] = (args ? args.maxSessionDuration : undefined) ?? 3600;
             resourceInputs["mfaAge"] = (args ? args.mfaAge : undefined) ?? 86400;
-            resourceInputs["poweruser"] = args ? (args.poweruser ? pulumi.output(args.poweruser).apply(inputs.poweruserRoleWithMFAArgsProvideDefaults) : undefined) : undefined;
-            resourceInputs["readonly"] = args ? (args.readonly ? pulumi.output(args.readonly).apply(inputs.readonlyRoleWithMFAArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["poweruser"] = args ? args.poweruser : undefined;
+            resourceInputs["readonly"] = args ? args.readonly : undefined;
             resourceInputs["trustedRoleArns"] = args ? args.trustedRoleArns : undefined;
             resourceInputs["trustedRoleServices"] = args ? args.trustedRoleServices : undefined;
         } else {

--- a/sdk/nodejs/assumableRolesWithSAML.ts
+++ b/sdk/nodejs/assumableRolesWithSAML.ts
@@ -60,9 +60,9 @@ export class AssumableRolesWithSAML extends pulumi.ComponentResource {
             resourceInputs["awsSamlEndpoint"] = (args ? args.awsSamlEndpoint : undefined) ?? "https://signin.aws.amazon.com/saml";
             resourceInputs["forceDetachPolicies"] = (args ? args.forceDetachPolicies : undefined) ?? false;
             resourceInputs["maxSessionDuration"] = (args ? args.maxSessionDuration : undefined) ?? 3600;
-            resourceInputs["poweruser"] = args ? (args.poweruser ? pulumi.output(args.poweruser).apply(inputs.poweruserRoleArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["poweruser"] = args ? args.poweruser : undefined;
             resourceInputs["providerIds"] = args ? args.providerIds : undefined;
-            resourceInputs["readonly"] = args ? (args.readonly ? pulumi.output(args.readonly).apply(inputs.readonlyRoleArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["readonly"] = args ? args.readonly : undefined;
         } else {
             resourceInputs["admin"] = undefined /*out*/;
             resourceInputs["poweruser"] = undefined /*out*/;

--- a/sdk/nodejs/eksrole.ts
+++ b/sdk/nodejs/eksrole.ts
@@ -92,7 +92,7 @@ export class EKSRole extends pulumi.ComponentResource {
             resourceInputs["forceDetachPolicies"] = (args ? args.forceDetachPolicies : undefined) ?? false;
             resourceInputs["maxSessionDuration"] = (args ? args.maxSessionDuration : undefined) ?? 3600;
             resourceInputs["providerUrlSaPairs"] = args ? args.providerUrlSaPairs : undefined;
-            resourceInputs["role"] = args ? (args.role ? pulumi.output(args.role).apply(inputs.roleArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["role"] = args ? args.role : undefined;
             resourceInputs["rolePolicyArns"] = args ? args.rolePolicyArns : undefined;
             resourceInputs["tags"] = args ? args.tags : undefined;
             resourceInputs["arn"] = undefined /*out*/;

--- a/sdk/nodejs/roleForServiceAccountsEks.ts
+++ b/sdk/nodejs/roleForServiceAccountsEks.ts
@@ -89,7 +89,7 @@ export class RoleForServiceAccountsEks extends pulumi.ComponentResource {
             resourceInputs["oidcProviders"] = args ? args.oidcProviders : undefined;
             resourceInputs["policies"] = args ? (args.policies ? pulumi.output(args.policies).apply(inputs.eksrolePoliciesArgsProvideDefaults) : undefined) : undefined;
             resourceInputs["policyNamePrefix"] = (args ? args.policyNamePrefix : undefined) ?? "AmazonEKS_";
-            resourceInputs["role"] = args ? (args.role ? pulumi.output(args.role).apply(inputs.eksserviceAccountRoleArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["role"] = args ? args.role : undefined;
             resourceInputs["tags"] = args ? args.tags : undefined;
         } else {
             resourceInputs["role"] = undefined /*out*/;

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -61,7 +61,7 @@ export interface AdminRoleArgs {
      */
     name?: pulumi.Input<string>;
     /**
-     * Path of admin IAM role.
+     * Path of admin IAM role. Defaults to '/'
      */
     path?: pulumi.Input<string>;
     /**
@@ -84,8 +84,6 @@ export function adminRoleArgsProvideDefaults(val: AdminRoleArgs): AdminRoleArgs 
     return {
         ...val,
         name: (val.name) ?? "admin",
-        path: (val.path) ?? "/",
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
     };
 }
 
@@ -117,15 +115,6 @@ export interface AdminRoleWithMFAArgs {
      * A map of tags to add.
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-}
-/**
- * adminRoleWithMFAArgsProvideDefaults sets the appropriate defaults for AdminRoleWithMFAArgs
- */
-export function adminRoleWithMFAArgsProvideDefaults(val: AdminRoleWithMFAArgs): AdminRoleWithMFAArgs {
-    return {
-        ...val,
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
-    };
 }
 
 /**
@@ -426,18 +415,6 @@ export interface EKSServiceAccountRoleArgs {
      */
     policyArns?: pulumi.Input<pulumi.Input<string>[]>;
 }
-/**
- * eksserviceAccountRoleArgsProvideDefaults sets the appropriate defaults for EKSServiceAccountRoleArgs
- */
-export function eksserviceAccountRoleArgsProvideDefaults(val: EKSServiceAccountRoleArgs): EKSServiceAccountRoleArgs {
-    return {
-        ...val,
-        name: (val.name) ?? "",
-        namePrefix: (val.namePrefix) ?? "",
-        path: (val.path) ?? "/",
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
-    };
-}
 
 /**
  * The VPC CNI IAM policy to the role.
@@ -517,17 +494,6 @@ export interface PoweruserRoleArgs {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }
-/**
- * poweruserRoleArgsProvideDefaults sets the appropriate defaults for PoweruserRoleArgs
- */
-export function poweruserRoleArgsProvideDefaults(val: PoweruserRoleArgs): PoweruserRoleArgs {
-    return {
-        ...val,
-        name: (val.name) ?? "poweruser",
-        path: (val.path) ?? "/",
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
-    };
-}
 
 /**
  * The poweruser role.
@@ -558,18 +524,6 @@ export interface PoweruserRoleWithMFAArgs {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }
-/**
- * poweruserRoleWithMFAArgsProvideDefaults sets the appropriate defaults for PoweruserRoleWithMFAArgs
- */
-export function poweruserRoleWithMFAArgsProvideDefaults(val: PoweruserRoleWithMFAArgs): PoweruserRoleWithMFAArgs {
-    return {
-        ...val,
-        name: (val.name) ?? "poweruser",
-        path: (val.path) ?? "/",
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
-        requiresMfa: (val.requiresMfa) ?? true,
-    };
-}
 
 /**
  * The readonly role.
@@ -580,7 +534,7 @@ export interface ReadonlyRoleArgs {
      */
     name?: pulumi.Input<string>;
     /**
-     * Path of readonly IAM role.
+     * Path of readonly IAM role. Defaults to '/'.
      */
     path?: pulumi.Input<string>;
     /**
@@ -596,17 +550,6 @@ export interface ReadonlyRoleArgs {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }
-/**
- * readonlyRoleArgsProvideDefaults sets the appropriate defaults for ReadonlyRoleArgs
- */
-export function readonlyRoleArgsProvideDefaults(val: ReadonlyRoleArgs): ReadonlyRoleArgs {
-    return {
-        ...val,
-        name: (val.name) ?? "readonly",
-        path: (val.path) ?? "/",
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
-    };
-}
 
 /**
  * The readonly role.
@@ -617,7 +560,7 @@ export interface ReadonlyRoleWithMFAArgs {
      */
     name?: pulumi.Input<string>;
     /**
-     * Path of readonly IAM role.
+     * Path of readonly IAM role. Defaults to '/'.
      */
     path?: pulumi.Input<string>;
     /**
@@ -637,18 +580,6 @@ export interface ReadonlyRoleWithMFAArgs {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }
-/**
- * readonlyRoleWithMFAArgsProvideDefaults sets the appropriate defaults for ReadonlyRoleWithMFAArgs
- */
-export function readonlyRoleWithMFAArgsProvideDefaults(val: ReadonlyRoleWithMFAArgs): ReadonlyRoleWithMFAArgs {
-    return {
-        ...val,
-        name: (val.name) ?? "readonly",
-        path: (val.path) ?? "/",
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
-        requiresMfa: (val.requiresMfa) ?? true,
-    };
-}
 
 /**
  * An IAM role.
@@ -663,7 +594,7 @@ export interface RoleArgs {
      */
     namePrefix?: pulumi.Input<string>;
     /**
-     * Path of admin IAM role.
+     * Path of admin IAM role. Defaults to '/'.
      */
     path?: pulumi.Input<string>;
     /**
@@ -675,29 +606,17 @@ export interface RoleArgs {
      */
     policyArns?: pulumi.Input<pulumi.Input<string>[]>;
 }
-/**
- * roleArgsProvideDefaults sets the appropriate defaults for RoleArgs
- */
-export function roleArgsProvideDefaults(val: RoleArgs): RoleArgs {
-    return {
-        ...val,
-        name: (val.name) ?? "",
-        namePrefix: (val.namePrefix) ?? "",
-        path: (val.path) ?? "/",
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
-    };
-}
 
 /**
  * An IAM role that requires MFA.
  */
 export interface RoleWithMFAArgs {
     /**
-     * IAM role with the access.
+     * IAM role with the access. Defaults to 'admin'.
      */
     name?: pulumi.Input<string>;
     /**
-     * Path of the IAM role.
+     * Path of the IAM role. Defaults to '/'.
      */
     path?: pulumi.Input<string>;
     /**
@@ -716,17 +635,5 @@ export interface RoleWithMFAArgs {
      * A map of tags to add.
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-}
-/**
- * roleWithMFAArgsProvideDefaults sets the appropriate defaults for RoleWithMFAArgs
- */
-export function roleWithMFAArgsProvideDefaults(val: RoleWithMFAArgs): RoleWithMFAArgs {
-    return {
-        ...val,
-        name: (val.name) ?? "admin",
-        path: (val.path) ?? "/",
-        permissionsBoundaryArn: (val.permissionsBoundaryArn) ?? "",
-        requiresMfa: (val.requiresMfa) ?? true,
-    };
 }
 

--- a/sdk/python/pulumi_aws_iam/_inputs.py
+++ b/sdk/python/pulumi_aws_iam/_inputs.py
@@ -214,8 +214,6 @@ class AdminRoleWithMFAArgs:
             pulumi.set(__self__, "name", name)
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
@@ -309,7 +307,7 @@ class AdminRoleArgs:
         """
         The admin role.
         :param pulumi.Input[str] name: IAM role with admin access.
-        :param pulumi.Input[str] path: Path of admin IAM role.
+        :param pulumi.Input[str] path: Path of admin IAM role. Defaults to '/'
         :param pulumi.Input[str] permissions_boundary_arn: Permissions boundary ARN to use for admin role.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] policy_arns: List of policy ARNs to use for admin role.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to add.
@@ -318,12 +316,8 @@ class AdminRoleArgs:
             name = 'admin'
         if name is not None:
             pulumi.set(__self__, "name", name)
-        if path is None:
-            path = '/'
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
@@ -347,7 +341,7 @@ class AdminRoleArgs:
     @pulumi.getter
     def path(self) -> Optional[pulumi.Input[str]]:
         """
-        Path of admin IAM role.
+        Path of admin IAM role. Defaults to '/'
         """
         return pulumi.get(self, "path")
 
@@ -1154,20 +1148,12 @@ class EKSServiceAccountRoleArgs:
         """
         if description is not None:
             pulumi.set(__self__, "description", description)
-        if name is None:
-            name = ''
         if name is not None:
             pulumi.set(__self__, "name", name)
-        if name_prefix is None:
-            name_prefix = ''
         if name_prefix is not None:
             pulumi.set(__self__, "name_prefix", name_prefix)
-        if path is None:
-            path = '/'
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
@@ -1470,22 +1456,14 @@ class PoweruserRoleWithMFAArgs:
         :param pulumi.Input[bool] requires_mfa: Whether admin role requires MFA.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to add.
         """
-        if name is None:
-            name = 'poweruser'
         if name is not None:
             pulumi.set(__self__, "name", name)
-        if path is None:
-            path = '/'
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
             pulumi.set(__self__, "policy_arns", policy_arns)
-        if requires_mfa is None:
-            requires_mfa = True
         if requires_mfa is not None:
             pulumi.set(__self__, "requires_mfa", requires_mfa)
         if tags is not None:
@@ -1580,16 +1558,10 @@ class PoweruserRoleArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] policy_arns: List of policy ARNs to use for poweruser role.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to add.
         """
-        if name is None:
-            name = 'poweruser'
         if name is not None:
             pulumi.set(__self__, "name", name)
-        if path is None:
-            path = '/'
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
@@ -1670,28 +1642,20 @@ class ReadonlyRoleWithMFAArgs:
         """
         The readonly role.
         :param pulumi.Input[str] name: IAM role with readonly access.
-        :param pulumi.Input[str] path: Path of readonly IAM role.
+        :param pulumi.Input[str] path: Path of readonly IAM role. Defaults to '/'.
         :param pulumi.Input[str] permissions_boundary_arn: Permissions boundary ARN to use for readonly role.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] policy_arns: List of policy ARNs to use for readonly role.
         :param pulumi.Input[bool] requires_mfa: Whether admin role requires MFA.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to add.
         """
-        if name is None:
-            name = 'readonly'
         if name is not None:
             pulumi.set(__self__, "name", name)
-        if path is None:
-            path = '/'
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
             pulumi.set(__self__, "policy_arns", policy_arns)
-        if requires_mfa is None:
-            requires_mfa = True
         if requires_mfa is not None:
             pulumi.set(__self__, "requires_mfa", requires_mfa)
         if tags is not None:
@@ -1713,7 +1677,7 @@ class ReadonlyRoleWithMFAArgs:
     @pulumi.getter
     def path(self) -> Optional[pulumi.Input[str]]:
         """
-        Path of readonly IAM role.
+        Path of readonly IAM role. Defaults to '/'.
         """
         return pulumi.get(self, "path")
 
@@ -1781,21 +1745,15 @@ class ReadonlyRoleArgs:
         """
         The readonly role.
         :param pulumi.Input[str] name: IAM role with readonly access.
-        :param pulumi.Input[str] path: Path of readonly IAM role.
+        :param pulumi.Input[str] path: Path of readonly IAM role. Defaults to '/'.
         :param pulumi.Input[str] permissions_boundary_arn: Permissions boundary ARN to use for readonly role.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] policy_arns: List of policy ARNs to use for readonly role.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to add.
         """
-        if name is None:
-            name = 'readonly'
         if name is not None:
             pulumi.set(__self__, "name", name)
-        if path is None:
-            path = '/'
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
@@ -1819,7 +1777,7 @@ class ReadonlyRoleArgs:
     @pulumi.getter
     def path(self) -> Optional[pulumi.Input[str]]:
         """
-        Path of readonly IAM role.
+        Path of readonly IAM role. Defaults to '/'.
         """
         return pulumi.get(self, "path")
 
@@ -1875,29 +1833,21 @@ class RoleWithMFAArgs:
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         An IAM role that requires MFA.
-        :param pulumi.Input[str] name: IAM role with the access.
-        :param pulumi.Input[str] path: Path of the IAM role.
+        :param pulumi.Input[str] name: IAM role with the access. Defaults to 'admin'.
+        :param pulumi.Input[str] path: Path of the IAM role. Defaults to '/'.
         :param pulumi.Input[str] permissions_boundary_arn: Permissions boundary ARN to use for the role.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] policy_arns: List of policy ARNs to use for the role.
         :param pulumi.Input[bool] requires_mfa: Whether the role requires MFA.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to add.
         """
-        if name is None:
-            name = 'admin'
         if name is not None:
             pulumi.set(__self__, "name", name)
-        if path is None:
-            path = '/'
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
             pulumi.set(__self__, "policy_arns", policy_arns)
-        if requires_mfa is None:
-            requires_mfa = True
         if requires_mfa is not None:
             pulumi.set(__self__, "requires_mfa", requires_mfa)
         if tags is not None:
@@ -1907,7 +1857,7 @@ class RoleWithMFAArgs:
     @pulumi.getter
     def name(self) -> Optional[pulumi.Input[str]]:
         """
-        IAM role with the access.
+        IAM role with the access. Defaults to 'admin'.
         """
         return pulumi.get(self, "name")
 
@@ -1919,7 +1869,7 @@ class RoleWithMFAArgs:
     @pulumi.getter
     def path(self) -> Optional[pulumi.Input[str]]:
         """
-        Path of the IAM role.
+        Path of the IAM role. Defaults to '/'.
         """
         return pulumi.get(self, "path")
 
@@ -1988,24 +1938,16 @@ class RoleArgs:
         An IAM role.
         :param pulumi.Input[str] name: IAM role name.
         :param pulumi.Input[str] name_prefix: IAM role name prefix.
-        :param pulumi.Input[str] path: Path of admin IAM role.
+        :param pulumi.Input[str] path: Path of admin IAM role. Defaults to '/'.
         :param pulumi.Input[str] permissions_boundary_arn: Permissions boundary ARN to use for the role.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] policy_arns: List of policy ARNs to use for the role.
         """
-        if name is None:
-            name = ''
         if name is not None:
             pulumi.set(__self__, "name", name)
-        if name_prefix is None:
-            name_prefix = ''
         if name_prefix is not None:
             pulumi.set(__self__, "name_prefix", name_prefix)
-        if path is None:
-            path = '/'
         if path is not None:
             pulumi.set(__self__, "path", path)
-        if permissions_boundary_arn is None:
-            permissions_boundary_arn = ''
         if permissions_boundary_arn is not None:
             pulumi.set(__self__, "permissions_boundary_arn", permissions_boundary_arn)
         if policy_arns is not None:
@@ -2039,7 +1981,7 @@ class RoleArgs:
     @pulumi.getter
     def path(self) -> Optional[pulumi.Input[str]]:
         """
-        Path of admin IAM role.
+        Path of admin IAM role. Defaults to '/'.
         """
         return pulumi.get(self, "path")
 


### PR DESCRIPTION
Related to: https://github.com/pulumi/pulumi-aws-iam/issues/8

This PR removes defaults from nested inputs until they are supported (https://github.com/pulumi/pulumi/issues/11726).

