### PR TITLE
correct NamespaceServiceAccounts to StringArrayOutput

### DIFF
--- a/provider/pkg/provider/role_for_service_account_eks.go
+++ b/provider/pkg/provider/role_for_service_account_eks.go
@@ -145,7 +145,7 @@ func NewRoleForServiceAccountsEks(ctx *pulumi.Context, name string, args *RoleFo
 
 	var oidcProviderOutputs []interface{}
 	for _, provider := range args.OIDCProviders {
-		providerOutput := pulumi.All(provider.NamespaceServiceAccounts, provider.ProviderARN).ApplyT(func(x []interface{}) iam.GetPolicyDocumentStatement {
+		providerOutput := pulumi.All(provider.NamespaceServiceAccounts.ToStringArrayOutput(), provider.ProviderARN).ApplyT(func(x []interface{}) iam.GetPolicyDocumentStatement {
 			namespaceServiceAccounts := x[0].([]string)
 			providerARN := x[1].(string)
 


### PR DESCRIPTION
This should resolve #10 by converting the `NamespaceServiceAccounts` to an `Output<string[]>`  so that it can be consumed properly.

Unfortunately setting up actions in our space ran into a build error with the dotnet portion because of incompatibility with dotnet 3.1 🤷 