### PR TITLE
remove unnecessary print in policy document

### DIFF
--- a/provider/pkg/provider/eks_role.go
+++ b/provider/pkg/provider/eks_role.go
@@ -134,11 +134,6 @@ func NewEKSRole(ctx *pulumi.Context, name string, args *EKSRoleArgs, opts ...pul
 		Statements: policyDocStatements,
 	})
 
-	assumeRoleWithOIDC.Json().ApplyT(func(data string) error {
-		fmt.Println(data)
-		return nil
-	})
-
 	role, err := utils.NewIAMRole(ctx, name, &utils.IAMRoleArgs{
 		Role:                args.Role,
 		AssumeRolePolicy:    assumeRoleWithOIDC.Json(),


### PR DESCRIPTION
Removing an unnecessary print that prints each policy document for every EKS role in a pulumi program. 